### PR TITLE
Set up Netlify builds for all branches and setup a staging site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,8 @@
   ID = "pwd-fishway"
 
 [build]
-  base    = "./src/app/"
-  publish = "./src/app/build/"
+  base    = "src/app/"
+  publish = "src/app/build/"
   command = "pushd ../.. && ./scripts/cibuild && popd"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 [build]
   base    = "src/app/"
   publish = "src/app/build/"
-  command = "pushd ../.. && ./scripts/cibuild && popd"
+  command = "yarn build"
 
 [[redirects]]
   from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,5 +17,4 @@
   Content-Security-Policy = "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'"
   X-Frame-Options = "DENY"
   X-XSS-Protection = "1; mode=block"
-  X-Content-Type-Options = "nosniff"
   Referrer-Policy = "origin-when-cross-origin"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,21 @@
+[Settings]
+  ID = "pwd-fishway"
+
+[build]
+  base    = "./src/app/"
+  publish = "./src/app/build/"
+  command = "pushd ../.. && ./scripts/cibuild && popd"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+[[headers]]
+  for = "/*"
+[headers.values]
+  Content-Security-Policy = "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'"
+  X-Frame-Options = "DENY"
+  X-XSS-Protection = "1; mode=block"
+  X-Content-Type-Options = "nosniff"
+  Referrer-Policy = "origin-when-cross-origin"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,9 @@
   ID = "pwd-fishway"
 
 [build]
-  base    = "src/app/"
-  publish = "src/app/build/"
-  command = "yarn build"
+  base    = "./src/app/"
+  publish = "./src/app/build/"
+  command = "pushd ../.. && ./scripts/cibuild && popd"
 
 [[redirects]]
   from = "/*"

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,23 +23,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        ./scripts/lint
-        ./scripts/test
+        pushd src/app
 
-        # Build static asset bundle
-        docker-compose run --rm --no-deps \
-                       -e NODE_ENV="${NODE_ENV:-production}" \
-                       -e INSTALL_ENV="${INSTALL_ENV:-internal}" \
-                       -e VERSION="${GIT_COMMIT}" app \
-                       yarn build
+        # Run linter
+        ./node_modules/.bin/eslint \
+        src/ --ext .js --ext .jsx --max-warnings=0
 
-        # If the cibuild.d directory exists, source each script it
-        # contains. This allows the core cibuild.sh to be extended with
-        # project specific scripts.
-        if [ -d "./scripts/cibuild.d" ]; then
-            for file in ./scripts/cibuild.d/*.sh; do
-                source "${file}"
-            done
-        fi
+        yarn build
+
+        popd
     fi
 fi

--- a/src/app/config/.eslintrc
+++ b/src/app/config/.eslintrc
@@ -17,7 +17,7 @@
     "settings": {
         "import/resolver": {
             "webpack": {
-                "config": "webpack.common.config.js"
+                "config": "webpack.config.js"
             }
         }
     }

--- a/src/app/config/webpackDevServer.config.js
+++ b/src/app/config/webpackDevServer.config.js
@@ -75,11 +75,7 @@ module.exports = function(proxy, allowedHost) {
     https: protocol === 'https',
     host,
     overlay: false,
-    historyApiFallback: {
-      // Paths with dots should still use the history fallback.
-      // See https://github.com/facebook/create-react-app/issues/387.
-      disableDotRule: true,
-    },
+    historyApiFallback: true,
     public: allowedHost,
     proxy,
     before(app, server) {

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -10,7 +10,6 @@
   "bugs": {
     "url": "https://github.com/azavea/pwd-fishway/issues"
   },
-  "homepage": "https://github.com/azavea/pwd-fishway",
   "dependencies": {
     "@babel/core": "7.2.2",
     "@svgr/webpack": "4.1.0",


### PR DESCRIPTION
## Overview

Because this project will be a static site and I enjoyed using Netlify on ISM, we will use Netlify to deploy and host sites for all branches and staging (points at `develop`). This PR sets up the project on Netlify.

The original issue suggests experimenting with zipping up the project and pushing it to Netlify to host. The motivation is that we'll need to zip the files up and upload them to the server at the museum. Rather than add that extra layer to the build process, we can manually zip up the files when the time comes for the exhibit installation.

Connects #2

## Notes

The Netlify credentials are in Lastpass under CivicApps, or should be anyway. The account is under my email jfung+civicapps at azavea.com

## Testing Instructions

Click the "Details" of the deploy preview on the PR footer to see the CRA!

Staging site (won't show the app properly until the Netlify config is merged in):
https://staging-pwd-fishway.netlify.com/
