### PR TITLE
Add component for See the Fishway

### DIFF
--- a/src/app/public/manifest.json
+++ b/src/app/public/manifest.json
@@ -1,6 +1,6 @@
 {
-    "short_name": "React App",
-    "name": "Create React App Sample",
+    "short_name": "Fishway",
+    "name": "Fishway",
     "icons": [
         {
             "src": "favicon.ico",

--- a/src/app/src/Navbar.js
+++ b/src/app/src/Navbar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Tabs from 'react-bootstrap/Tabs';
 import Tab from 'react-bootstrap/Tab';
+import SeeTheFishway from './SeeTheFishway';
 
 import About from './About';
 
@@ -10,8 +11,8 @@ export default function Navbar() {
             <Tab eventKey='about' title='About'>
                 <About />
             </Tab>
-            <Tab eventKey='view' title='View from the Fishway'>
-                <div>View from the Fishway</div>
+            <Tab eventKey='see' title='See the Fishway'>
+                <SeeTheFishway />
             </Tab>
             <Tab eventKey='meet' title='Meet the Fish'>
                 <div>Meet the Fish</div>

--- a/src/app/src/SeeTheFishway.js
+++ b/src/app/src/SeeTheFishway.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function SeeTheFishway() {
+    return (
+        <div className='see-the-fishway'>
+            <div className='library'>
+                <div className='library__description'>
+                    <h1>See the Fishway</h1>
+                    During the Spring migration, a video camera transmits live
+                    images to this exhibit, and to aquatic biologists.
+                    Biologists monitor fish moving up and down the river. In
+                    Springtime, fish travel upriver to their spawning grounds,
+                    to mate and lay eggs. This is when the Fish Ladder is most
+                    active.
+                </div>
+                <div className='videos' />
+            </div>
+            <div className='video-panel' />
+        </div>
+    );
+}

--- a/src/app/src/css/main.css
+++ b/src/app/src/css/main.css
@@ -1,3 +1,4 @@
 @import "about.css";
 @import "navbar.css";
 @import "screensaver.css";
+@import "seethefishway.css";

--- a/src/app/src/css/seethefishway.css
+++ b/src/app/src/css/seethefishway.css
@@ -1,0 +1,7 @@
+.see-the-fishway {
+    display: flex;
+}
+
+.video-panel {
+    min-width: 300px;
+}


### PR DESCRIPTION
## Overview

Adds a basic component for the See the Fishway component.
The name was changed to See the Fishway according to the latest designs in Abstract.

Connects #13

### Demo
<img width="902" alt="Screen Shot 2019-04-29 at 4 28 35 PM" src="https://user-images.githubusercontent.com/10568752/56924855-f090b000-6a9b-11e9-9948-87b9780884a6.png">

### Notes
I am not 100% satisfied with my name choices for this component and for the CSS classes 🤔 

## Testing Instructions

Netlify is sufficient.