### PR TITLE
Add Rebass

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -63,6 +63,7 @@
     "react-redux": "~5.0.7",
     "react-router": "~4.2.0",
     "react-router-dom": "~4.2.2",
+    "rebass": "^3.1.0",
     "redux": "~3.7.2",
     "redux-act": "~1.7.4",
     "redux-logger": "~3.0.6",

--- a/src/app/src/ClipSelect.js
+++ b/src/app/src/ClipSelect.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Box, Heading, Text } from 'rebass';
+
+const ClipSelect = () => {
+    return (
+        <Box bg='lightgray'>
+            <Heading as='h2' fontSize='2'>
+                Highlight reel
+            </Heading>
+            <Text as='p' fontSize='0'>
+                Check out some of the wildlife that scientists have caught on
+                tape over the years.
+            </Text>
+        </Box>
+    );
+};
+
+export default ClipSelect;

--- a/src/app/src/ClipSelect.js
+++ b/src/app/src/ClipSelect.js
@@ -1,9 +1,15 @@
 import React from 'react';
+import styled from 'styled-components';
 import { Box, Heading, Text } from 'rebass';
+import { themeGet } from 'styled-system';
+
+const StyledClipSelect = styled(Box)`
+    background: ${themeGet('colors.lightgray')};
+`;
 
 const ClipSelect = () => {
     return (
-        <Box bg='lightgray'>
+        <StyledClipSelect>
             <Heading as='h2' fontSize='2'>
                 Highlight reel
             </Heading>
@@ -11,7 +17,7 @@ const ClipSelect = () => {
                 Check out some of the wildlife that scientists have caught on
                 tape over the years.
             </Text>
-        </Box>
+        </StyledClipSelect>
     );
 };
 

--- a/src/app/src/MeetTheFish.js
+++ b/src/app/src/MeetTheFish.js
@@ -1,28 +1,25 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Flex, Box, Heading, Text } from 'rebass';
 
-const Header = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-`;
-
-const Text = styled.p`
+const StyledMeetTheFish = styled(Flex)`
+    justify-content: center;
     text-align: center;
-    width: 400px;
 `;
 
 const MeetTheFish = () => {
     return (
-        <div>
-            <Header>
-                <Text as='h3'>Meet the Fish</Text>
-                <Text>
+        <StyledMeetTheFish>
+            <Box width={1 / 2}>
+                <Heading as='h1' fontSize='2' mb='3'>
+                    Meet the Fish
+                </Heading>
+                <Text as='p' fontSize='1'>
                     Did you know over 48 species of fish live in the waterways
                     of Philadelphia? Here are 24 of the most common species.
                 </Text>
-            </Header>
-        </div>
+            </Box>
+        </StyledMeetTheFish>
     );
 };
 

--- a/src/app/src/Quiz.js
+++ b/src/app/src/Quiz.js
@@ -1,46 +1,33 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Flex, Box, Heading, Text, Button } from 'rebass';
 
-const StyledQuiz = styled.div`
-    display: flex;
+const StyledQuiz = styled(Flex)`
+    text-align: center;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
 `;
-
-const Description = styled.div`
-    width: 500px;
-    text-align: center;
-    margin-bottom: 50px;
-`;
-
-const Button = styled.button`
-    border-radius: 15px;
-    box-shadow: 0px 4px 12px 0px rgba(17, 20, 39, 0.9);
-    height: 70px;
-    width: 200px;
-`;
-
-const Text = styled.p``;
 
 const Quiz = () => {
     return (
         <StyledQuiz>
-            <Description>
-                <Text as='h1'>Test your skills</Text>
-                <Text as='h4'>
+            <Box width={1 / 2} mb='4'>
+                <Heading as='h1' fontSize='3' mb='4'>
+                    Test your skills
+                </Heading>
+                <Text as='p' fontSize='1'>
                     Aquatic biologists need to identify each fish that moves
                     through the fishway. This can be tough, because fish swim
                     fast and are hard to see!
                 </Text>
-                <Text>
+                <Text as='p'>
                     Watch the clip of fish moving through the fishway and match
                     it to the correct fish. Work quickly and carefully to get
                     the highest score!
                 </Text>
-            </Description>
-            <Button>
-                <Text as='h2'>PLAY</Text>
-            </Button>
+            </Box>
+            <Button>Play</Button>
         </StyledQuiz>
     );
 };

--- a/src/app/src/Screensaver.js
+++ b/src/app/src/Screensaver.js
@@ -1,43 +1,43 @@
-import React from "react";
-import { connect } from "react-redux";
-import { func } from "prop-types";
-import { hideScreensaver } from "./actions";
-import styled from "styled-components";
-import { Flex, Box, Heading, Button } from "rebass";
+import React from 'react';
+import { connect } from 'react-redux';
+import { func } from 'prop-types';
+import { hideScreensaver } from './actions';
+import styled from 'styled-components';
+import { Flex, Box, Heading, Button } from 'rebass';
 
 const StyledScreensaver = styled(Flex)`
-  text-align: center;
+    text-align: center;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
 `;
 
 const Screensaver = props => {
-  const { dispatch } = props;
+    const { dispatch } = props;
 
-  return (
-    <StyledScreensaver
-      flexDirection="column"
-      alignItems="center"
-      justifyContent="center"
-      className="screensaver"
-      onClick={() => dispatch(hideScreensaver())}
-    >
-      <Box width={1 / 2}>
-        <Heading as="h1" fontSize="3" mb="4">
-          Learn how the fish ladder helps fish populations and whether you have
-          what it takes to be an aquatic biologist.
-        </Heading>
-        <Button className="screensaver__button">Let's go!</Button>
-      </Box>
-    </StyledScreensaver>
-  );
+    return (
+        <StyledScreensaver
+            className='screensaver'
+            onClick={() => dispatch(hideScreensaver())}
+        >
+            <Box width={1 / 2}>
+                <Heading as='h1' fontSize='3' mb='4'>
+                    Learn how the fish ladder helps fish populations and whether
+                    you have what it takes to be an aquatic biologist.
+                </Heading>
+                <Button className='screensaver__button'>Let's go!</Button>
+            </Box>
+        </StyledScreensaver>
+    );
 };
 
 Screensaver.propTypes = {
-  dispatch: func.isRequired
+    dispatch: func.isRequired,
 };
 
 function mapStateToProps(state) {
-  return {
-    dispatch: state.dispatch
-  };
+    return {
+        dispatch: state.dispatch,
+    };
 }
 export default connect(mapStateToProps)(Screensaver);

--- a/src/app/src/Screensaver.js
+++ b/src/app/src/Screensaver.js
@@ -16,16 +16,13 @@ const Screensaver = props => {
     const { dispatch } = props;
 
     return (
-        <StyledScreensaver
-            className='screensaver'
-            onClick={() => dispatch(hideScreensaver())}
-        >
+        <StyledScreensaver onClick={() => dispatch(hideScreensaver())}>
             <Box width={1 / 2}>
                 <Heading as='h1' fontSize='3' mb='4'>
                     Learn how the fish ladder helps fish populations and whether
                     you have what it takes to be an aquatic biologist.
                 </Heading>
-                <Button className='screensaver__button'>Let's go!</Button>
+                <Button>Let's go!</Button>
             </Box>
         </StyledScreensaver>
     );

--- a/src/app/src/Screensaver.js
+++ b/src/app/src/Screensaver.js
@@ -1,48 +1,43 @@
-import React from 'react';
-import { connect } from 'react-redux';
-import { func } from 'prop-types';
-import { hideScreensaver } from './actions';
-import styled from 'styled-components';
+import React from "react";
+import { connect } from "react-redux";
+import { func } from "prop-types";
+import { hideScreensaver } from "./actions";
+import styled from "styled-components";
+import { Flex, Box, Heading, Button } from "rebass";
 
-const StyledScreensaver = styled.div`
-    display: flex;
-    height: 100%;
-    flex-direction: column;
-    align-items: center;
-
-    p {
-        font-size: 2rem;
-        margin-top: 40vh;
-        text-align: center;
-    }
+const StyledScreensaver = styled(Flex)`
+  text-align: center;
 `;
 
 const Screensaver = props => {
-    const { dispatch } = props;
+  const { dispatch } = props;
 
-    return (
-        <StyledScreensaver
-            className='screensaver'
-            onClick={() => dispatch(hideScreensaver())}
-        >
-            <p>
-                Learn how the fish ladder helps fish populations and whether you
-                have what it takes to be an aquatic biologist.
-            </p>
-            <button type='button' className='screensaver__button'>
-                Let's go!
-            </button>
-        </StyledScreensaver>
-    );
+  return (
+    <StyledScreensaver
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      className="screensaver"
+      onClick={() => dispatch(hideScreensaver())}
+    >
+      <Box width={1 / 2}>
+        <Heading as="h1" fontSize="3" mb="4">
+          Learn how the fish ladder helps fish populations and whether you have
+          what it takes to be an aquatic biologist.
+        </Heading>
+        <Button className="screensaver__button">Let's go!</Button>
+      </Box>
+    </StyledScreensaver>
+  );
 };
 
 Screensaver.propTypes = {
-    dispatch: func.isRequired,
+  dispatch: func.isRequired
 };
 
 function mapStateToProps(state) {
-    return {
-        dispatch: state.dispatch,
-    };
+  return {
+    dispatch: state.dispatch
+  };
 }
 export default connect(mapStateToProps)(Screensaver);

--- a/src/app/src/SeeTheFishway.js
+++ b/src/app/src/SeeTheFishway.js
@@ -1,31 +1,31 @@
 import React from 'react';
-import styled from 'styled-components';
-
-const StyledSeeTheFishway = styled.div`
-    display: flex;
-
-    .video-panel {
-        min-width: 300px;
-    }
-`;
+import { Flex, Box, Heading, Text } from 'rebass';
+import Sidebar from './Sidebar.js';
+import ClipSelect from './ClipSelect.js';
 
 const SeeTheFishway = () => {
     return (
-        <StyledSeeTheFishway>
-            <div className='library'>
-                <div className='library__description'>
-                    <h1>See the Fishway</h1>
-                    During the Spring migration, a video camera transmits live
-                    images to this exhibit, and to aquatic biologists.
-                    Biologists monitor fish moving up and down the river. In
-                    Springtime, fish travel upriver to their spawning grounds,
-                    to mate and lay eggs. This is when the Fish Ladder is most
-                    active.
-                </div>
-                <div className='videos' />
-            </div>
-            <div className='video-panel' />
-        </StyledSeeTheFishway>
+        <div>
+            <Flex>
+                <Box>
+                    <Heading as='h1' fontSize='2' mb='3'>
+                        See the Fishway
+                    </Heading>
+                    <Text as='p' fontSize='1'>
+                        During the Spring migration, a video camera transmits
+                        live images to this exhibit, and to aquatic biologists.
+                    </Text>
+                    <Text as='p'>
+                        Biologists monitor fish moving up and down the river. In
+                        Springtime, fish travel upriver to their spawning
+                        grounds, to mate and lay eggs. This is when the Fish
+                        Ladder is most active.
+                    </Text>
+                </Box>
+                <Sidebar />
+            </Flex>
+            <ClipSelect />
+        </div>
     );
 };
 

--- a/src/app/src/Sidebar.js
+++ b/src/app/src/Sidebar.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Box, Heading } from 'rebass';
+
+const StyledSidebar = styled(Box)`
+    width: 300px;
+`;
+
+const Sidebar = () => {
+    return (
+        <StyledSidebar bg='lightgray'>
+            <Heading as='h2' fontSize='2'>
+                Sidebar
+            </Heading>
+        </StyledSidebar>
+    );
+};
+
+export default Sidebar;

--- a/src/app/src/Sidebar.js
+++ b/src/app/src/Sidebar.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Box, Heading } from 'rebass';
+import { themeGet } from 'styled-system';
 
 const StyledSidebar = styled(Box)`
     width: 300px;
+    background: ${themeGet('colors.lightgray')};
 `;
 
 const Sidebar = () => {
     return (
-        <StyledSidebar bg='lightgray'>
+        <StyledSidebar>
             <Heading as='h2' fontSize='2'>
                 Sidebar
             </Heading>

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -1,22 +1,22 @@
-import React from "react";
-import { render } from "react-dom";
-import { Provider } from "react-redux";
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider } from 'react-redux';
 
-import * as serviceWorker from "./serviceWorker";
-import { store } from "./store";
+import * as serviceWorker from './serviceWorker';
+import { store } from './store';
 
-import { ThemeProvider } from "styled-components";
-import theme from "./theme";
+import { ThemeProvider } from 'styled-components';
+import theme from './theme';
 
-import App from "./App";
+import App from './App';
 
 render(
-  <Provider store={store}>
-    <ThemeProvider theme={theme}>
-      <App />
-    </ThemeProvider>
-  </Provider>,
-  document.getElementById("root")
+    <Provider store={store}>
+        <ThemeProvider theme={theme}>
+            <App />
+        </ThemeProvider>
+    </Provider>,
+    document.getElementById('root')
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -1,17 +1,22 @@
-import React from 'react';
-import { render } from 'react-dom';
-import { Provider } from 'react-redux';
+import React from "react";
+import { render } from "react-dom";
+import { Provider } from "react-redux";
 
-import * as serviceWorker from './serviceWorker';
-import { store } from './store';
+import * as serviceWorker from "./serviceWorker";
+import { store } from "./store";
 
-import App from './App';
+import { ThemeProvider } from "styled-components";
+import theme from "./theme";
+
+import App from "./App";
 
 render(
-    <Provider store={store}>
-        <App />
-    </Provider>,
-    document.getElementById('root')
+  <Provider store={store}>
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
+  </Provider>,
+  document.getElementById("root")
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/app/src/theme.js
+++ b/src/app/src/theme.js
@@ -1,0 +1,26 @@
+export default {
+  breakpoints: ["40em", "52em", "64em"],
+  fontSizes: [
+    "1rem",
+    "1.2rem",
+    "1.5rem",
+    "1.8rem",
+    "2.2rem",
+    "2.6rem",
+    "2.9rem",
+    "3.4rem"
+  ],
+  colors: {
+    blue: "#07c",
+    lightgray: "#f6f6ff"
+  },
+  space: [0, 4, 8, 16, 32, 64, 128, 256],
+  fonts: {
+    sans: "system-ui, sans-serif",
+    mono: "Menlo, monospace"
+  },
+  shadows: {
+    small: "0 0 4px rgba(0, 0, 0, .125)",
+    large: "0 0 24px rgba(0, 0, 0, .125)"
+  }
+};

--- a/src/app/src/theme.js
+++ b/src/app/src/theme.js
@@ -1,26 +1,26 @@
 export default {
-  breakpoints: ["40em", "52em", "64em"],
-  fontSizes: [
-    "1rem",
-    "1.2rem",
-    "1.5rem",
-    "1.8rem",
-    "2.2rem",
-    "2.6rem",
-    "2.9rem",
-    "3.4rem"
-  ],
-  colors: {
-    blue: "#07c",
-    lightgray: "#f6f6ff"
-  },
-  space: [0, 4, 8, 16, 32, 64, 128, 256],
-  fonts: {
-    sans: "system-ui, sans-serif",
-    mono: "Menlo, monospace"
-  },
-  shadows: {
-    small: "0 0 4px rgba(0, 0, 0, .125)",
-    large: "0 0 24px rgba(0, 0, 0, .125)"
-  }
+    breakpoints: ['40em', '52em', '64em'],
+    fontSizes: [
+        '1rem',
+        '1.2rem',
+        '1.5rem',
+        '1.8rem',
+        '2.2rem',
+        '2.6rem',
+        '2.9rem',
+        '3.4rem',
+    ],
+    colors: {
+        blue: '#07c',
+        lightgray: '#f6f6ff',
+    },
+    space: [0, 4, 8, 16, 32, 64, 128, 256],
+    fonts: {
+        sans: 'system-ui, sans-serif',
+        mono: 'Menlo, monospace',
+    },
+    shadows: {
+        small: '0 0 4px rgba(0, 0, 0, .125)',
+        large: '0 0 24px rgba(0, 0, 0, .125)',
+    },
 };

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -8821,6 +8821,13 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rebass@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rebass/-/rebass-3.1.0.tgz#6f3779a20fd5e196623f45463b2aa8843e5feb5e"
+  integrity sha512-FtmBb0bDT8q8HaGT4uAiJAQKZOdMsdonx6vp/cjnPc23FdMoo74ClTm0vJAwkWY1KzA0LCvmPbyGvWE0FFMR8w==
+  dependencies:
+    styled-system "^4.0.8"
+
 recursive-readdir@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
@@ -9867,6 +9874,14 @@ styled-components@^4.2.0:
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
+
+styled-system@^4.0.8:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-4.1.0.tgz#e5a58be23b89cf8fb7b181c8e425ab107b166693"
+  integrity sha512-ioIAJ029tRr6eJhiUrE3VZeahN+GBuJHv/jmckkfikY4ej8BaxvIKAaavmjFoqzNsIzr+x5HCpry1ybQYpchtQ==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    prop-types "^15.7.2"
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
## Overview
This PR adds the Rebass library and applies it to the `<Screensaver/>` component. I've also added a `theme.js` file and added some placeholder specs to start with (coming directly from the Theming page in the [Rebass docs](https://rebassjs.org/theming)). 

Eventually when we want to style the components to match the ones from our app, we'll extend them in individual files. For now, I'm just using the Rebass components as-is.

Connects #45

### Demo
<img width="1680" alt="Screen Shot 2019-05-02 at 1 47 38 PM" src="https://user-images.githubusercontent.com/5672295/57095466-edd2cc80-6ce0-11e9-9b4b-f641f87fb6b1.png">

### Notes
- Styles don't yet match the designs in Abstract. They will once #48 is implemented.
- We will eventually want to add these components into our project so we can change up some of their styles—I'm happy to do that in this PR if it feels appropriate.
- Also happy to style other pages of the app as a part of this PR—just didn't want to cause issues for anything that others might be working on.

## Testing Instructions
* `git pull`
* If server is running, stop to run `./scripts/update` and then rerun server.
* Confirm that Rebass is imported correctly, and there aren't errors in the console.
* Confirm that Screensaver component looks like the screenshot.
