### PR TITLE
Kick user to the screensaver and reset app upon idle

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -59,6 +59,7 @@
     "react-dev-utils": "^8.0.0",
     "react-dom": "^16.8.5",
     "react-hot-loader": "~4.0.1",
+    "react-idle-timer": "^4.2.5",
     "react-leaflet": "~1.9.1",
     "react-redux": "~5.0.7",
     "react-router": "~4.2.0",

--- a/src/app/src/About.js
+++ b/src/app/src/About.js
@@ -1,13 +1,13 @@
 import Carousel from 'nuka-carousel';
 import { PagingDots } from 'nuka-carousel/lib';
 import { func, number } from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { themeGet } from 'styled-system';
 import { Heading } from './custom-styled-components';
 
-import { saveAboutSlideIndex } from './actions';
+import { saveAboutSlideIndex, resetTimer } from './actions';
 import AboutSlide from './AboutSlide';
 import { ABOUT_PROFILES } from './constants';
 
@@ -24,40 +24,48 @@ const StyledAbout = styled.div`
     }
 `;
 
-const About = props => {
-    const { dispatch, aboutSlideIndex } = props;
+class About extends Component {
+    componentWillUnmount() {
+        const { dispatch } = this.props;
+        dispatch(resetTimer());
+    }
 
-    const slides = ABOUT_PROFILES.map((profile, index) => (
-        <AboutSlide
-            key={index}
-            active={index === aboutSlideIndex}
-            {...profile}
-        />
-    ));
+    render() {
+        const { dispatch, aboutSlideIndex } = this.props;
 
-    return (
-        <StyledAbout>
-            <Heading as='h1' textAlign='center'>
-                About
-            </Heading>
-            <Carousel
-                autoplay={false}
-                cellAlign={'center'}
-                renderCenterLeftControls={null}
-                renderCenterRightControls={null}
-                renderBottomCenterControls={null}
-                renderTopCenterControls={props => <PagingDots {...props} />}
-                slideIndex={aboutSlideIndex}
-                slidesToShow={slidesToShow}
-                afterSlide={slideIndex =>
-                    dispatch(saveAboutSlideIndex(slideIndex))
-                }
-            >
-                {slides}
-            </Carousel>
-        </StyledAbout>
-    );
-};
+        const slides = ABOUT_PROFILES.map((profile, index) => (
+            <AboutSlide
+                key={index}
+                active={index === aboutSlideIndex}
+                {...profile}
+                dispatch={dispatch}
+            />
+        ));
+
+        return (
+            <StyledAbout>
+                <Heading as='h1' textAlign='center'>
+                    About
+                </Heading>
+                <Carousel
+                    autoplay={false}
+                    cellAlign={'center'}
+                    renderCenterLeftControls={null}
+                    renderCenterRightControls={null}
+                    renderBottomCenterControls={null}
+                    renderTopCenterControls={props => <PagingDots {...props} />}
+                    slideIndex={aboutSlideIndex}
+                    slidesToShow={slidesToShow}
+                    afterSlide={slideIndex =>
+                        dispatch(saveAboutSlideIndex(slideIndex))
+                    }
+                >
+                    {slides}
+                </Carousel>
+            </StyledAbout>
+        );
+    }
+}
 
 About.propTypes = {
     aboutSlideIndex: number.isRequired,

--- a/src/app/src/AboutSlide.js
+++ b/src/app/src/AboutSlide.js
@@ -3,6 +3,8 @@ import { Button, Flex } from 'rebass';
 import { Heading, Text } from './custom-styled-components';
 import styled from 'styled-components';
 
+import { pauseTimer, resetTimer } from './actions';
+
 const StyledAboutSlide = styled(Flex)`
     height: 80vh;
     padding: 1rem;
@@ -61,7 +63,15 @@ export default class AboutSlide extends Component {
     }
 
     render() {
-        const { active, description, job, name, title, videoPath } = this.props;
+        const {
+            active,
+            description,
+            job,
+            name,
+            title,
+            videoPath,
+            dispatch,
+        } = this.props;
 
         return (
             <StyledAboutSlide>
@@ -71,6 +81,9 @@ export default class AboutSlide extends Component {
                         autoPlay={active}
                         src={videoPath}
                         onClick={this.togglePlayPause}
+                        onPlay={() => dispatch(pauseTimer())}
+                        onPause={() => dispatch(resetTimer())}
+                        onEnded={() => dispatch(resetTimer())}
                     />
                     {!this.state.playing && (
                         <PlayButton onClick={this.togglePlayPause}>

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -7,7 +7,7 @@ import Navbar from './Navbar';
 import Screensaver from './Screensaver';
 import GlobalStyle from './globalStyle';
 import { resetAppState } from './actions';
-import { RESET, PAUSE } from './constants';
+import { RESET, PAUSE, MAX_IDLE_TIME } from './constants';
 
 class App extends Component {
     constructor() {
@@ -17,16 +17,16 @@ class App extends Component {
         this.pauseTimer = this.pauseTimer.bind(this);
     }
 
-    shouldComponentUpdate(nextProps) {
-        const { timerEvent: nextTimerEvent } = nextProps;
-        if (nextTimerEvent !== this.props.timerEvent) {
-            if (nextTimerEvent === RESET) {
+    componentDidUpdate(prevProps) {
+        const { timerEvent: prevTimerEvent } = prevProps;
+        const { timerEvent: currentTimerEvent } = this.props;
+        if (this.idleTimer && prevTimerEvent !== currentTimerEvent) {
+            if (currentTimerEvent === RESET) {
                 this.resetTimer();
-            } else if (nextTimerEvent === PAUSE) {
+            } else if (currentTimerEvent === PAUSE) {
                 this.pauseTimer();
             }
         }
-        return true;
     }
 
     pauseTimer() {
@@ -48,7 +48,7 @@ class App extends Component {
                 element={document}
                 onIdle={() => dispatch(resetAppState())}
                 onAction={this.resetTimer}
-                timeout={5000}
+                timeout={MAX_IDLE_TIME}
             />
         );
         return (

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -1,18 +1,60 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { bool } from 'prop-types';
+import { bool, func, string } from 'prop-types';
+import IdleTimer from 'react-idle-timer';
 
 import Navbar from './Navbar';
 import Screensaver from './Screensaver';
 import GlobalStyle from './globalStyle';
+import { resetAppState } from './actions';
+import { RESET, PAUSE } from './constants';
 
 class App extends Component {
+    constructor() {
+        super();
+        this.idleTimer = null;
+        this.resetTimer = this.resetTimer.bind(this);
+        this.pauseTimer = this.pauseTimer.bind(this);
+    }
+
+    shouldComponentUpdate(nextProps) {
+        const { timerEvent: nextTimerEvent } = nextProps;
+        if (nextTimerEvent !== this.props.timerEvent) {
+            if (nextTimerEvent === RESET) {
+                this.resetTimer();
+            } else if (nextTimerEvent === PAUSE) {
+                this.pauseTimer();
+            }
+        }
+        return true;
+    }
+
+    pauseTimer() {
+        this.idleTimer.pause();
+    }
+
+    resetTimer() {
+        this.idleTimer.reset();
+    }
+
     render() {
-        const { isScreensaverVisible } = this.props;
+        const { isScreensaverVisible, dispatch } = this.props;
         const app = isScreensaverVisible ? <Screensaver /> : <Navbar />;
+        const idleTimer = (
+            <IdleTimer
+                ref={ref => {
+                    this.idleTimer = ref;
+                }}
+                element={document}
+                onIdle={() => dispatch(resetAppState())}
+                onAction={this.resetTimer}
+                timeout={5000}
+            />
+        );
         return (
             <div className='App'>
                 <GlobalStyle />
+                {!isScreensaverVisible && idleTimer}
                 {app}
             </div>
         );
@@ -21,11 +63,15 @@ class App extends Component {
 
 App.propTypes = {
     isScreensaverVisible: bool.isRequired,
+    dispatch: func.isRequired,
+    timerEvent: string.isRequired,
 };
 
 function mapStateToProps(state) {
     return {
         isScreensaverVisible: state.isScreensaverVisible,
+        dispatch: state.dispatch,
+        timerEvent: state.timerEvent,
     };
 }
 export default connect(mapStateToProps)(App);

--- a/src/app/src/actions.js
+++ b/src/app/src/actions.js
@@ -1,6 +1,7 @@
 import { createAction } from 'redux-act';
 
 export const hideScreensaver = createAction('Hide screensaver');
-export const showScreensaver = createAction('Show screensaver');
-
+export const resetAppState = createAction('Reset default app state');
 export const saveAboutSlideIndex = createAction('Change About slide index');
+export const resetTimer = createAction('Reset timer');
+export const pauseTimer = createAction('Pause timer');

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -1,5 +1,6 @@
 export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
+export const MAX_IDLE_TIME = 5000; //in ms
 
 export const ABOUT_PROFILES = [
     {

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -1,3 +1,6 @@
+export const PAUSE = 'PAUSE';
+export const RESET = 'RESET';
+
 export const ABOUT_PROFILES = [
     {
         title: 'About the Fishway',

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -1,6 +1,6 @@
 export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
-export const MAX_IDLE_TIME = 5000; //in ms
+export const MAX_IDLE_TIME = 10000; //in ms
 
 export const ABOUT_PROFILES = [
     {

--- a/src/app/src/reducers.js
+++ b/src/app/src/reducers.js
@@ -4,12 +4,16 @@ import update from 'immutability-helper';
 import {
     hideScreensaver,
     saveAboutSlideIndex,
-    showScreensaver,
+    resetAppState,
+    resetTimer,
+    pauseTimer,
 } from './actions';
+import { RESET, PAUSE } from './constants';
 
 export const initialState = {
     aboutSlideIndex: 0,
     isScreensaverVisible: true,
+    timerEvent: '',
 };
 
 export default createReducer(
@@ -18,11 +22,9 @@ export default createReducer(
             update(state, { aboutSlideIndex: { $set: payload } }),
         [hideScreensaver]: state =>
             update(state, { isScreensaverVisible: { $set: false } }),
-        [showScreensaver]: state =>
-            update(state, {
-                aboutSlideIndex: { $set: initialState.aboutSlideIndex },
-                isScreensaverVisible: { $set: true },
-            }),
+        [resetAppState]: state => update(state, { $set: initialState }),
+        [resetTimer]: state => update(state, { timerEvent: { $set: RESET } }),
+        [pauseTimer]: state => update(state, { timerEvent: { $set: PAUSE } }),
     },
     initialState
 );

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -8654,6 +8654,11 @@ react-hot-loader@~4.0.1:
     prop-types "^15.6.1"
     shallowequal "^1.0.2"
 
+react-idle-timer@^4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/react-idle-timer/-/react-idle-timer-4.2.5.tgz#eb7d6e1b318f7755b5e0ee810254a8e95a2271b7"
+  integrity sha512-8B/OwjG8E/DTx1fHYKTpZ4cnCbL9+LOc5I9t8SYe8tbEkP14KChiYg0xPIuyRpO33wUZHcgmQl93CVePaDhmRA==
+
 react-is@^16.3.2, react-is@^16.6.0:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"


### PR DESCRIPTION
## Overview

When the app goes idle, we want to reset the app state and display the screensaver. Furthermore, a video playing should not count as idle time. This PR adds this timer via[ react-idle-timer ](https://github.com/SupremeTechnopriest/react-idle-timer)and sets it up to be controlled by videos across the app.

The timer is set to time out after 5 seconds in this PR. In production that number will be much higher (a minute?).

~The two actions will fit in nicely with how videos are manually controlled in #50 . Playing a video should call `pauseTimer`. A video stopping manually should call `resetTimer`. TBD how to detect a video stopping for other reasons like playing through to the end. When switching tabs suddenly, we can hook into unmounting lifecycle hooks.~ Implemented because #50 was merged. Open to rethinking this workflow, because Redux doesn't feel like it was built to solve this problem -- but using it does the job.

Connects #16 

### Notes

Before merging:
- I will drop c48aaff -- I did that work to test that hooking into the timer works from any other component.
- I will up the time out so it's not so much in the way during development. It can easily be turned off or bumped up in time.

## Testing Instructions
`./scripts/update` if testing locally
Click into the app and test the app goes to screensaver after 5 seconds.
The timer should reset back to 5s with any touch or movement.
Interact with the buttons on the quiz tab and see the app behaves as expected
Interact with the videos and switch tabs and see that the timeout behaves as expected.

