### PR TITLE
Add theme styles from designs

### DIFF
--- a/src/app/src/About.js
+++ b/src/app/src/About.js
@@ -18,8 +18,9 @@ const StyledAbout = styled.div`
     padding-top: 1rem;
     background: ${themeGet('colors.teals.4')};
 
-    > h2 {
-        text-align: center;
+    .about__slide {
+        height: 80vh;
+        padding: 1rem;
     }
 `;
 
@@ -36,7 +37,9 @@ const About = props => {
 
     return (
         <StyledAbout>
-            <Heading as='h2'>About</Heading>
+            <Heading as='h1' textAlign='center'>
+                About
+            </Heading>
             <Carousel
                 autoplay={false}
                 cellAlign={'center'}

--- a/src/app/src/About.js
+++ b/src/app/src/About.js
@@ -4,6 +4,8 @@ import { func, number } from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
+import { themeGet } from 'styled-system';
+import { Heading, Text } from '../src';
 
 import { saveAboutSlideIndex } from './actions';
 import AboutSlide from './AboutSlide';
@@ -14,6 +16,7 @@ const slidesToShow = 1.3;
 
 const StyledAbout = styled.div`
     padding-top: 1rem;
+    background: ${themeGet('colors.teals.4')};
 
     > h2 {
         text-align: center;
@@ -33,7 +36,7 @@ const About = props => {
 
     return (
         <StyledAbout>
-            <h2>About</h2>
+            <Heading as='h2'>About</Heading>
             <Carousel
                 autoplay={false}
                 cellAlign={'center'}

--- a/src/app/src/About.js
+++ b/src/app/src/About.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { themeGet } from 'styled-system';
-import { Heading, Text } from '../src';
+import { Heading } from '../src';
 
 import { saveAboutSlideIndex } from './actions';
 import AboutSlide from './AboutSlide';

--- a/src/app/src/About.js
+++ b/src/app/src/About.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { themeGet } from 'styled-system';
-import { Heading } from '../src';
+import { Heading } from './custom-styled-components';
 
 import { saveAboutSlideIndex } from './actions';
 import AboutSlide from './AboutSlide';

--- a/src/app/src/AboutSlide.js
+++ b/src/app/src/AboutSlide.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Button, Flex, Heading, Text } from 'rebass';
+import { Button, Flex } from 'rebass';
+import { Heading, Text } from '../src';
 import styled from 'styled-components';
 
 const StyledAboutSlide = styled(Flex)`
@@ -83,13 +84,19 @@ export default class AboutSlide extends Component {
                     margin='auto'
                     flexDirection='column'
                 >
-                    <Heading as='h3'>{title}</Heading>
+                    <Heading as='h2' variant='small'>
+                        {title}
+                    </Heading>
                     {job && (
                         <>
-                            <Heading as='h4'>Name</Heading>
+                            <Heading as='h3' variant='xSmall'>
+                                Name
+                            </Heading>
                             <Text>{name}</Text>
                             <Text>{job}</Text>
-                            <Heading as='h4'>What he does</Heading>
+                            <Heading as='h3' variant='xSmall'>
+                                What he does
+                            </Heading>
                         </>
                     )}
                     <Text>{description}</Text>

--- a/src/app/src/AboutSlide.js
+++ b/src/app/src/AboutSlide.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Button, Flex } from 'rebass';
-import { Heading, Text } from '../src';
+import { Heading, Text } from './custom-styled-components';
 import styled from 'styled-components';
 
 const StyledAboutSlide = styled(Flex)`

--- a/src/app/src/ClipSelect.js
+++ b/src/app/src/ClipSelect.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box, Heading, Text } from 'rebass';
+import { Box } from 'rebass';
+import { Heading, Text } from '../src';
 import { themeGet } from 'styled-system';
 
 const StyledClipSelect = styled(Box)`
@@ -10,7 +11,7 @@ const StyledClipSelect = styled(Box)`
 const ClipSelect = () => {
     return (
         <StyledClipSelect>
-            <Heading as='h2' fontSize='2'>
+            <Heading as='h2' fontSize='2' variant='sectionTitle'>
                 Highlight reel
             </Heading>
             <Text as='p' fontSize='0'>

--- a/src/app/src/ClipSelect.js
+++ b/src/app/src/ClipSelect.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Box } from 'rebass';
-import { Heading, Text } from '../src';
+import { Heading, Text } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 
 const StyledClipSelect = styled(Box)`

--- a/src/app/src/ClipSelect.js
+++ b/src/app/src/ClipSelect.js
@@ -11,10 +11,10 @@ const StyledClipSelect = styled(Box)`
 const ClipSelect = () => {
     return (
         <StyledClipSelect>
-            <Heading as='h2' fontSize='2' variant='sectionTitle'>
+            <Heading as='h2' variant='small'>
                 Highlight reel
             </Heading>
-            <Text as='p' fontSize='0'>
+            <Text as='p'>
                 Check out some of the wildlife that scientists have caught on
                 tape over the years.
             </Text>

--- a/src/app/src/Heading.js
+++ b/src/app/src/Heading.js
@@ -46,6 +46,10 @@ const Heading = styled(BaseHeading)`
 
 Heading.displayName = 'Heading';
 
+Heading.propTypes = {
+    variant: PropTypes.string.isRequired,
+};
+
 Heading.PropTypes = {
     ...variant.PropTypes,
 };

--- a/src/app/src/Heading.js
+++ b/src/app/src/Heading.js
@@ -33,6 +33,15 @@ const Heading = styled(BaseHeading)`
             font-weight: ${themeGet('fontWeights.semibold')};
             margin-bottom: ${themeGet('space.small')};
         `};
+    ${props =>
+        props.variant === 'xSmall' &&
+        css`
+            font-size: ${themeGet('fontSizes.1')};
+            font-weight: ${themeGet('fontWeights.semibold')};
+            margin-bottom: ${themeGet('space.small')};
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        `};
 `;
 
 Heading.displayName = 'Heading';

--- a/src/app/src/Heading.js
+++ b/src/app/src/Heading.js
@@ -1,0 +1,53 @@
+import { Heading as BaseHeading } from 'rebass';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { themeGet, style } from 'styled-system';
+
+const variant = style({
+    prop: 'variant',
+    cssProperty: 'variant',
+});
+
+const Heading = styled(BaseHeading)`
+    ${props =>
+        props.variant === 'intro' &&
+        css`
+            font-size: ${themeGet('fontSizes.4')};
+            color: ${themeGet('colors.white')};
+            font-weight: ${themeGet('fontWeights.medium')};
+            line-height: ${themeGet('lineHeights.normal')};
+            text-shadow: ${themeGet('shadows.large')};
+            margin-bottom: ${themeGet('space.medium')};
+            opacity: 0.95;
+        `};
+    ${props =>
+        props.variant === 'pageTitle' &&
+        css`
+            font-size: ${themeGet('fontSizes.3')};
+            color: ${themeGet('colors.white')};
+            font-weight: ${themeGet('fontWeights.semibold')};
+            line-height: ${themeGet('lineHeights.normal')};
+            margin-bottom: ${themeGet('space.compact')};
+        `};
+    ${props =>
+        props.variant === 'sectionTitle' &&
+        css`
+            font-size: ${themeGet('fontSizes.2')};
+            color: ${themeGet('colors.white')};
+            font-weight: ${themeGet('fontWeights.semibold')};
+            line-height: ${themeGet('lineHeights.normal')};
+            margin-bottom: ${themeGet('space.small')};
+        `};
+`;
+
+Heading.displayName = 'Heading';
+
+Heading.PropTypes = {
+    ...variant.PropTypes,
+};
+
+Heading.defaultProps = {
+    variant: 'pageTitle',
+};
+
+export default Heading;

--- a/src/app/src/Heading.js
+++ b/src/app/src/Heading.js
@@ -9,33 +9,28 @@ const variant = style({
 });
 
 const Heading = styled(BaseHeading)`
+    color: ${themeGet('colors.white')};
+    line-height: ${themeGet('lineHeights.normal')};
+
     ${props =>
-        props.variant === 'intro' &&
+        props.variant === 'medium' &&
         css`
             font-size: ${themeGet('fontSizes.4')};
-            color: ${themeGet('colors.white')};
             font-weight: ${themeGet('fontWeights.medium')};
-            line-height: ${themeGet('lineHeights.normal')};
-            text-shadow: ${themeGet('shadows.large')};
             margin-bottom: ${themeGet('space.medium')};
-            opacity: 0.95;
         `};
     ${props =>
-        props.variant === 'pageTitle' &&
+        props.variant === 'base' &&
         css`
             font-size: ${themeGet('fontSizes.3')};
-            color: ${themeGet('colors.white')};
             font-weight: ${themeGet('fontWeights.semibold')};
-            line-height: ${themeGet('lineHeights.normal')};
             margin-bottom: ${themeGet('space.compact')};
         `};
     ${props =>
-        props.variant === 'sectionTitle' &&
+        props.variant === 'small' &&
         css`
             font-size: ${themeGet('fontSizes.2')};
-            color: ${themeGet('colors.white')};
             font-weight: ${themeGet('fontWeights.semibold')};
-            line-height: ${themeGet('lineHeights.normal')};
             margin-bottom: ${themeGet('space.small')};
         `};
 `;
@@ -47,7 +42,7 @@ Heading.PropTypes = {
 };
 
 Heading.defaultProps = {
-    variant: 'pageTitle',
+    variant: 'base',
 };
 
 export default Heading;

--- a/src/app/src/MeetTheFish.js
+++ b/src/app/src/MeetTheFish.js
@@ -14,10 +14,8 @@ const MeetTheFish = () => {
     return (
         <StyledMeetTheFish>
             <Box width={1 / 2}>
-                <Heading as='h1' fontSize='2' mb='3'>
-                    Meet the Fish
-                </Heading>
-                <Text as='p' fontSize='1' variant='big'>
+                <Heading as='h1'>Meet the Fish</Heading>
+                <Text as='p' variant='large'>
                     Did you know over 48 species of fish live in the waterways
                     of Philadelphia? Here are 24 of the most common species.
                 </Text>

--- a/src/app/src/MeetTheFish.js
+++ b/src/app/src/MeetTheFish.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Flex, Box, Heading, Text } from 'rebass';
+import { Flex, Box } from 'rebass';
+import { Heading, Text } from '../src';
+import { themeGet } from 'styled-system';
 
 const StyledMeetTheFish = styled(Flex)`
     justify-content: center;
     text-align: center;
+    background: ${themeGet('colors.teals.1')};
 `;
 
 const MeetTheFish = () => {
@@ -14,7 +17,7 @@ const MeetTheFish = () => {
                 <Heading as='h1' fontSize='2' mb='3'>
                     Meet the Fish
                 </Heading>
-                <Text as='p' fontSize='1'>
+                <Text as='p' fontSize='1' variant='big'>
                     Did you know over 48 species of fish live in the waterways
                     of Philadelphia? Here are 24 of the most common species.
                 </Text>

--- a/src/app/src/MeetTheFish.js
+++ b/src/app/src/MeetTheFish.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Flex, Box } from 'rebass';
-import { Heading, Text } from '../src';
+import { Heading, Text } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 
 const StyledMeetTheFish = styled(Flex)`

--- a/src/app/src/Quiz.js
+++ b/src/app/src/Quiz.js
@@ -1,22 +1,23 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Flex, Box, Heading, Text, Button } from 'rebass';
+import { Flex, Box, Button } from 'rebass';
+import { Heading, Text } from '../src';
+import { themeGet } from 'styled-system';
 
 const StyledQuiz = styled(Flex)`
     text-align: center;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    background: ${themeGet('colors.teals.0')};
 `;
 
 const Quiz = () => {
     return (
         <StyledQuiz>
             <Box width={1 / 2} mb='4'>
-                <Heading as='h1' fontSize='3' mb='4'>
-                    Test your skills
-                </Heading>
-                <Text as='p' fontSize='1'>
+                <Heading as='h1'>Test your skills</Heading>
+                <Text as='p' variant='big'>
                     Aquatic biologists need to identify each fish that moves
                     through the fishway. This can be tough, because fish swim
                     fast and are hard to see!
@@ -27,7 +28,7 @@ const Quiz = () => {
                     the highest score!
                 </Text>
             </Box>
-            <Button>Play</Button>
+            <Button mt='compact'>Play</Button>
         </StyledQuiz>
     );
 };

--- a/src/app/src/Quiz.js
+++ b/src/app/src/Quiz.js
@@ -17,7 +17,7 @@ const Quiz = () => {
         <StyledQuiz>
             <Box width={1 / 2} mb='4'>
                 <Heading as='h1'>Test your skills</Heading>
-                <Text as='p' variant='big'>
+                <Text as='p' variant='large'>
                     Aquatic biologists need to identify each fish that moves
                     through the fishway. This can be tough, because fish swim
                     fast and are hard to see!

--- a/src/app/src/Quiz.js
+++ b/src/app/src/Quiz.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Flex, Box, Button } from 'rebass';
-import { Heading, Text } from '../src';
+import { Heading, Text } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 
 const StyledQuiz = styled(Flex)`

--- a/src/app/src/Screensaver.js
+++ b/src/app/src/Screensaver.js
@@ -21,7 +21,12 @@ const Screensaver = props => {
     return (
         <StyledScreensaver onClick={() => dispatch(hideScreensaver())}>
             <Box>
-                <Heading as='h1' variant='intro'>
+                <Heading
+                    as='h1'
+                    variant='medium'
+                    textShadow='large'
+                    opacity='0.95'
+                >
                     Learn how the fish ladder helps fish populations and whether
                     you have what it takes to be an aquatic biologist.
                 </Heading>

--- a/src/app/src/Screensaver.js
+++ b/src/app/src/Screensaver.js
@@ -3,13 +3,16 @@ import { connect } from 'react-redux';
 import { func } from 'prop-types';
 import { hideScreensaver } from './actions';
 import styled from 'styled-components';
-import { Flex, Box, Heading, Button } from 'rebass';
+import { Flex, Box, Button } from 'rebass';
+import { Heading } from '../src';
+import { themeGet } from 'styled-system';
 
 const StyledScreensaver = styled(Flex)`
     text-align: center;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    background: ${themeGet('colors.teals.0')};
 `;
 
 const Screensaver = props => {
@@ -17,8 +20,8 @@ const Screensaver = props => {
 
     return (
         <StyledScreensaver onClick={() => dispatch(hideScreensaver())}>
-            <Box width={1 / 2}>
-                <Heading as='h1' fontSize='3' mb='4'>
+            <Box>
+                <Heading as='h1' variant='intro'>
                     Learn how the fish ladder helps fish populations and whether
                     you have what it takes to be an aquatic biologist.
                 </Heading>

--- a/src/app/src/Screensaver.js
+++ b/src/app/src/Screensaver.js
@@ -4,7 +4,7 @@ import { func } from 'prop-types';
 import { hideScreensaver } from './actions';
 import styled from 'styled-components';
 import { Flex, Box, Button } from 'rebass';
-import { Heading } from '../src';
+import { Heading } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 
 const StyledScreensaver = styled(Flex)`

--- a/src/app/src/SeeTheFishway.js
+++ b/src/app/src/SeeTheFishway.js
@@ -1,17 +1,25 @@
 import React from 'react';
-import { Flex, Box, Heading, Text } from 'rebass';
+import { Flex, Box } from 'rebass';
+import { Heading, Text } from '../src';
 import Sidebar from './Sidebar.js';
 import ClipSelect from './ClipSelect.js';
+import styled from 'styled-components';
+import { themeGet } from 'styled-system';
+
+const StyledSeeTheFishway = styled.div`
+    height: 100%;
+    background: ${themeGet('colors.teals.2')};
+`;
 
 const SeeTheFishway = () => {
     return (
-        <div>
+        <StyledSeeTheFishway>
             <Flex>
                 <Box>
                     <Heading as='h1' fontSize='2' mb='3'>
                         See the Fishway
                     </Heading>
-                    <Text as='p' fontSize='1'>
+                    <Text as='p' fontSize='1' variant='big'>
                         During the Spring migration, a video camera transmits
                         live images to this exhibit, and to aquatic biologists.
                     </Text>
@@ -25,7 +33,7 @@ const SeeTheFishway = () => {
                 <Sidebar />
             </Flex>
             <ClipSelect />
-        </div>
+        </StyledSeeTheFishway>
     );
 };
 

--- a/src/app/src/SeeTheFishway.js
+++ b/src/app/src/SeeTheFishway.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Flex, Box } from 'rebass';
-import { Heading, Text } from '../src';
+import { Heading, Text } from './custom-styled-components';
 import Sidebar from './Sidebar.js';
 import ClipSelect from './ClipSelect.js';
 import styled from 'styled-components';

--- a/src/app/src/SeeTheFishway.js
+++ b/src/app/src/SeeTheFishway.js
@@ -16,10 +16,8 @@ const SeeTheFishway = () => {
         <StyledSeeTheFishway>
             <Flex>
                 <Box>
-                    <Heading as='h1' fontSize='2' mb='3'>
-                        See the Fishway
-                    </Heading>
-                    <Text as='p' fontSize='1' variant='big'>
+                    <Heading as='h1'>See the Fishway</Heading>
+                    <Text as='p' variant='large'>
                         During the Spring migration, a video camera transmits
                         live images to this exhibit, and to aquatic biologists.
                     </Text>

--- a/src/app/src/Sidebar.js
+++ b/src/app/src/Sidebar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Box } from 'rebass';
-import { Heading } from '../src';
+import { Heading } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 
 const StyledSidebar = styled(Box)`

--- a/src/app/src/Sidebar.js
+++ b/src/app/src/Sidebar.js
@@ -12,7 +12,7 @@ const StyledSidebar = styled(Box)`
 const Sidebar = () => {
     return (
         <StyledSidebar>
-            <Heading as='h2' fontSize='2' variant='sectionTitle'>
+            <Heading as='h2' variant='small'>
                 Sidebar
             </Heading>
         </StyledSidebar>

--- a/src/app/src/Sidebar.js
+++ b/src/app/src/Sidebar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box, Heading } from 'rebass';
+import { Box } from 'rebass';
+import { Heading } from '../src';
 import { themeGet } from 'styled-system';
 
 const StyledSidebar = styled(Box)`
@@ -11,7 +12,7 @@ const StyledSidebar = styled(Box)`
 const Sidebar = () => {
     return (
         <StyledSidebar>
-            <Heading as='h2' fontSize='2'>
+            <Heading as='h2' fontSize='2' variant='sectionTitle'>
                 Sidebar
             </Heading>
         </StyledSidebar>

--- a/src/app/src/Text.js
+++ b/src/app/src/Text.js
@@ -9,26 +9,27 @@ const variant = style({
 });
 
 const Text = styled(BaseText)`
-    ${props =>
-        props.variant === 'big' &&
-        css`
-            font-size: ${themeGet('fontSizes.1')};
-            color: ${themeGet('colors.white')};
-            font-weight: ${themeGet('fontWeights.medium')};
-            line-height: ${themeGet('lineHeights.normal')};
-            margin-bottom: ${themeGet('space.small')};
-            opacity: 0.8;
-        `};
+    color: ${themeGet('colors.white')};
+    font-weight: ${themeGet('fontWeights.normal')};
+    line-height: ${themeGet('lineHeights.normal')};
+    margin-bottom: ${themeGet('space.small')};
+    opacity: 0.8;
 
     ${props =>
-        props.variant === 'body' &&
+        props.variant === 'large' &&
+        css`
+            font-size: ${themeGet('fontSizes.2')};
+            font-weight: ${themeGet('fontWeights.medium')};
+        `};
+    ${props =>
+        props.variant === 'base' &&
+        css`
+            font-size: ${themeGet('fontSizes.1')};
+        `};
+    ${props =>
+        props.variant === 'small' &&
         css`
             font-size: ${themeGet('fontSizes.0')};
-            color: ${themeGet('colors.white')};
-            font-weight: ${themeGet('fontWeights.normal')};
-            line-height: ${themeGet('lineHeights.normal')};
-            margin-bottom: ${themeGet('space.small')};
-            opacity: 0.8;
         `};
 `;
 
@@ -39,7 +40,7 @@ Text.PropTypes = {
 };
 
 Text.defaultProps = {
-    variant: 'body',
+    variant: 'base',
 };
 
 export default Text;

--- a/src/app/src/Text.js
+++ b/src/app/src/Text.js
@@ -35,6 +35,10 @@ const Text = styled(BaseText)`
 
 Text.displayName = 'Text';
 
+Text.propTypes = {
+    variant: PropTypes.string.isRequired,
+};
+
 Text.PropTypes = {
     ...variant.PropTypes,
 };

--- a/src/app/src/Text.js
+++ b/src/app/src/Text.js
@@ -1,0 +1,45 @@
+import { Text as BaseText } from 'rebass';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { themeGet, style } from 'styled-system';
+
+const variant = style({
+    prop: 'variant',
+    cssProperty: 'variant',
+});
+
+const Text = styled(BaseText)`
+    ${props =>
+        props.variant === 'big' &&
+        css`
+            font-size: ${themeGet('fontSizes.1')};
+            color: ${themeGet('colors.white')};
+            font-weight: ${themeGet('fontWeights.medium')};
+            line-height: ${themeGet('lineHeights.normal')};
+            margin-bottom: ${themeGet('space.small')};
+            opacity: 0.8;
+        `};
+
+    ${props =>
+        props.variant === 'body' &&
+        css`
+            font-size: ${themeGet('fontSizes.0')};
+            color: ${themeGet('colors.white')};
+            font-weight: ${themeGet('fontWeights.normal')};
+            line-height: ${themeGet('lineHeights.normal')};
+            margin-bottom: ${themeGet('space.small')};
+            opacity: 0.8;
+        `};
+`;
+
+Text.displayName = 'Text';
+
+Text.PropTypes = {
+    ...variant.PropTypes,
+};
+
+Text.defaultProps = {
+    variant: 'body',
+};
+
+export default Text;

--- a/src/app/src/custom-styled-components.js
+++ b/src/app/src/custom-styled-components.js
@@ -1,0 +1,2 @@
+export { default as Heading } from './Heading';
+export { default as Text } from './Text';

--- a/src/app/src/globalStyle.js
+++ b/src/app/src/globalStyle.js
@@ -70,12 +70,10 @@ const GlobalStyle = createGlobalStyle`
     /* Global styles */
     html {
        font-size: 16px;
-       font-family: 'Fira Sans';
+       font-family: Fira Sans, Helvetica, Arial, sans-serif;
     }
     body {
        line-height: 1;
-       font-family: 'Fira Sans', 'Helvetica', sans-serif;
-       font-weight: 400;
     }
 
     #root, 

--- a/src/app/src/globalStyle.js
+++ b/src/app/src/globalStyle.js
@@ -70,6 +70,7 @@ const GlobalStyle = createGlobalStyle`
     /* Global styles */
     html {
        font-size: 16px;
+       font-family: 'Fira Sans';
     }
     body {
        line-height: 1;

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -10,9 +10,6 @@ import theme from './theme';
 
 import App from './App';
 
-export { default as Heading } from './Heading';
-export { default as Text } from './Text';
-
 render(
     <Provider store={store}>
         <ThemeProvider theme={theme}>

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -10,6 +10,9 @@ import theme from './theme';
 
 import App from './App';
 
+export { default as Heading } from './Heading';
+export { default as Text } from './Text';
+
 render(
     <Provider store={store}>
         <ThemeProvider theme={theme}>

--- a/src/app/src/theme.js
+++ b/src/app/src/theme.js
@@ -1,26 +1,64 @@
 export default {
-    breakpoints: ['40em', '52em', '64em'],
-    fontSizes: [
-        '1rem',
-        '1.2rem',
-        '1.5rem',
-        '1.8rem',
-        '2.2rem',
-        '2.6rem',
-        '2.9rem',
-        '3.4rem',
-    ],
-    colors: {
-        blue: '#07c',
-        lightgray: '#f6f6ff',
+    breakpoints: {
+        small: '40em',
+        medium: '52em',
+        large: '64em',
     },
-    space: [0, 4, 8, 16, 32, 64, 128, 256],
-    fonts: {
-        sans: 'system-ui, sans-serif',
-        mono: 'Menlo, monospace',
+    fontSizes: [
+        '1rem', // 0
+        '1.2rem', // 1
+        '1.5rem', // 2
+        '2.25rem', // 3
+        '3.375rem', // 4
+        '4.5rem', // 5
+        '7.594rem', // 6
+        '11.391rem', // 7
+    ],
+    fontWeights: {
+        normal: '400',
+        medium: '500',
+        semibold: '600',
+        black: '800',
+    },
+    lineHeights: {
+        compact: '1',
+        normal: '1.25',
+        comfortable: '1.85',
+    },
+    colors: {
+        white: '#fff',
+        lightblue: '#E7FDFF',
+        greens: ['#e9f563', '#CEE007'],
+        red: '#C5603B',
+        teals: [
+            '#296882',
+            '#205064',
+            '#1b4455',
+            '#163846',
+            '#112c37',
+            '#0d2029',
+        ],
+        xlighttan: '#fffdf9',
+        lighttan: '#FBF8F4',
+        darkbrown: '#443E34',
+        black: '#000',
+    },
+    space: {
+        tiny: '2px',
+        small: '0.5rem',
+        compact: '1rem',
+        medium: '1.4rem',
+        normal: '2rem',
+        comfortable: '3rem',
+        spacious: '6rem',
+        large: '8rem',
+    },
+    maxWidths: {
+        small: '42.875rem',
+        wide: '104.500rem',
     },
     shadows: {
         small: '0 0 4px rgba(0, 0, 0, .125)',
-        large: '0 0 24px rgba(0, 0, 0, .125)',
+        large: '0 0 24px rgba(0, 0, 0, .30)',
     },
 };


### PR DESCRIPTION
## Overview
This PR adds correct styles for font sizes, colors, line-heights and more. I also extended `<Heading>` and `<Text>` and created variants based on the designs for us to use. More details on that in the notes.

Connects #48, connects #47

### Demo
![Screen Shot 2019-05-07 at 5 52 20 PM](https://user-images.githubusercontent.com/5672295/57335544-eea89b80-70f0-11e9-9f15-58ed52690a74.png)
![Screen Shot 2019-05-08 at 11 05 48 AM](https://user-images.githubusercontent.com/5672295/57385898-4abb0080-7181-11e9-806d-ce30e8eb7dc9.png)

![Screen Shot 2019-05-07 at 5 52 27 PM](https://user-images.githubusercontent.com/5672295/57335546-ef413200-70f0-11e9-826c-a2cd8955e0b0.png)
![Screen Shot 2019-05-07 at 5 52 29 PM](https://user-images.githubusercontent.com/5672295/57335547-ef413200-70f0-11e9-85df-b5fbb316ff69.png)
![Screen Shot 2019-05-07 at 5 52 31 PM](https://user-images.githubusercontent.com/5672295/57335548-ef413200-70f0-11e9-8701-112b96a8984c.png)

### Notes
- `<Text>` and `<Header>` are the first components from Rebass that we are extending. I focused primarily on creating styles for text that exists.
- To style `<Header>` and `<Text>` components in a consistent way, we are using custom variants. Knowing that we will want to have access to theme variables from `theme.js` meant that we cannot use the default variant `textStyles:[]` from Styled System (described [here](https://styled-system.com/api) under "Variant"). The solution I went with allows us to simply pass the prop `variant='variant-type'` to each of these components. We will likely handle `<Button>` variants this way for the same reasons.
- Naming conventions of small, base and medium don't map directly to a font size, they are intentionally scoped to actual usage of each component.
- We will eventually want to change up colors directly within components, but I'm not sure how to set up these variants to be override-able defaults. 
- I added some placeholder background colors to different screens, so that the text is readable. 
- I applied the new extended components to all available screens.
- Note that `<Button>` looks messed up now. I figured I'd hold off on addressing this until #49

## Testing Instructions
* `git pull`
* Switch out the `<Header>` variants to see what they look like
* Switch out the `<Text>` variants to see what they look like.
* Change out a variable within one of the variants (color is an easy one to see).

