### PR TITLE
Add in correct guess component with demo

### DIFF
--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Flex, Box } from 'rebass';
+import { Flex, Box, Button } from 'rebass';
 import { themeGet } from 'styled-system';
 
 import QuizNavbar from './QuizNavbar';
 import QuizGuess from './QuizGuess';
 import Sidebar from './Sidebar';
 
-import { QUIZ_FISH } from '../util/constants';
+import { QUIZ_FISH, GUESS_MESSAGE } from '../util/constants';
 
 const QuizContainer = styled(Flex)`
     text-align: center;
@@ -15,13 +15,32 @@ const QuizContainer = styled(Flex)`
 `;
 
 const Quiz = props => {
+    const [answer] = useState(QUIZ_FISH[0]);
+    const [guess, setGuess] = useState(null);
+
+    function checkGuess(fish) {
+        setGuess(fish);
+        setTimeout(() => setGuess(null), GUESS_MESSAGE);
+    }
+
+    const quizState = guess ? (
+        <QuizGuess answer={answer} guess={guess} />
+    ) : (
+        <QuizContainer>
+            <Sidebar />
+            <Button onClick={event => checkGuess(QUIZ_FISH[0])}>
+                Guess correctly
+            </Button>
+            <Button onClick={event => checkGuess(QUIZ_FISH[1])}>
+                Guess incorrectly
+            </Button>
+        </QuizContainer>
+    );
+
     return (
         <Box>
             <QuizNavbar dispatch={props.dispatch} />
-            <QuizContainer>
-                <Sidebar />
-                <QuizGuess answer={QUIZ_FISH[0]} guess={QUIZ_FISH[0]} />
-            </QuizContainer>
+            {quizState}
         </Box>
     );
 };

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -7,7 +7,7 @@ import QuizNavbar from './QuizNavbar';
 import QuizGuess from './QuizGuess';
 import Sidebar from './Sidebar';
 
-import { QUIZ_FISH, GUESS_MESSAGE } from '../util/constants';
+import { QUIZ_FISH, GUESS_MESSAGE_TIME } from '../util/constants';
 
 const QuizContainer = styled(Flex)`
     text-align: center;
@@ -20,7 +20,7 @@ const Quiz = props => {
 
     function checkGuess(fish) {
         setGuess(fish);
-        setTimeout(() => setGuess(null), GUESS_MESSAGE);
+        setTimeout(() => setGuess(null), GUESS_MESSAGE_TIME);
     }
 
     const quizState = guess ? (

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -4,7 +4,10 @@ import { Flex, Box } from 'rebass';
 import { themeGet } from 'styled-system';
 
 import QuizNavbar from './QuizNavbar';
+import QuizGuess from './QuizGuess';
 import Sidebar from './Sidebar';
+
+import { QUIZ_FISH } from '../util/constants';
 
 const QuizContainer = styled(Flex)`
     text-align: center;
@@ -17,6 +20,7 @@ const Quiz = props => {
             <QuizNavbar dispatch={props.dispatch} />
             <QuizContainer>
                 <Sidebar />
+                <QuizGuess answer={QUIZ_FISH[0]} guess={QUIZ_FISH[0]} />
             </QuizContainer>
         </Box>
     );

--- a/src/app/src/components/QuizGuess.js
+++ b/src/app/src/components/QuizGuess.js
@@ -1,11 +1,22 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box } from 'rebass';
+import { Flex } from 'rebass';
+import { objectOf } from 'prop-types';
 import { themeGet } from 'styled-system';
 
-const StyledQuizGuess = styled(Box)`
+import Text from './Text';
+
+import { QuizFish } from '../util/QuizFish';
+
+const StyledQuizGuess = styled(Flex)`
     text-align: center;
     background: ${themeGet('colors.teals.0')};
+    flex-direction: column;
+`;
+
+const Answer = styled(Flex)`
+    flex-direction: column;
+    text-align: center;
 `;
 
 const QuizGuess = props => {
@@ -18,18 +29,26 @@ const QuizGuess = props => {
 
     return (
         <StyledQuizGuess>
-            {message}
-            <img src={answer.picturePath} alt='Illustration of the fish' />
-            {answer.commonName}
-            {answer.scientificName}
-            {answer.hint}
+            <Answer>
+                {message}
+                <img src={answer.picturePath} alt='Illustration of the fish' />
+                <Text as='h2' variant='base'>
+                    {answer.commonName}
+                </Text>
+                <Text as='h3' variant='xSmall'>
+                    {answer.scientificName}
+                </Text>
+            </Answer>
+            <Text as='h2' variant='xSmall'>
+                {answer.hint}
+            </Text>
         </StyledQuizGuess>
     );
 };
 
 QuizGuess.propTypes = {
-    answer: Object.isRequired,
-    guess: Object.isRequired,
+    answer: objectOf(QuizFish).isRequired,
+    guess: objectOf(QuizFish).isRequired,
 };
 
 export default QuizGuess;

--- a/src/app/src/components/QuizGuess.js
+++ b/src/app/src/components/QuizGuess.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Box } from 'rebass';
+import { themeGet } from 'styled-system';
+
+const StyledQuizGuess = styled(Box)`
+    text-align: center;
+    background: ${themeGet('colors.teals.0')};
+`;
+
+const QuizGuess = props => {
+    const { answer, guess } = props;
+
+    const message =
+        answer.commonName === guess.commonName
+            ? 'CORRECT!'
+            : 'Sorry, it was the:';
+
+    return (
+        <StyledQuizGuess>
+            {message}
+            <img src={answer.picturePath} alt='Illustration of the fish' />
+            {answer.commonName}
+            {answer.scientificName}
+            {answer.hint}
+        </StyledQuizGuess>
+    );
+};
+
+QuizGuess.propTypes = {
+    answer: Object.isRequired,
+    guess: Object.isRequired,
+};
+
+export default QuizGuess;

--- a/src/app/src/components/QuizNavbar.js
+++ b/src/app/src/components/QuizNavbar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { func } from 'prop-types';
 import styled from 'styled-components';
 import { Flex, Button, Text } from 'rebass';
 
@@ -24,6 +25,10 @@ const QuizNavbar = props => {
             <Button onClick={() => dispatch(hideQuiz())}>x</Button>
         </StyledQuizNavbar>
     );
+};
+
+QuizNavbar.propTypes = {
+    dispatch: func.isRequired,
 };
 
 export default QuizNavbar;

--- a/src/app/src/util/QuizFish.js
+++ b/src/app/src/util/QuizFish.js
@@ -1,0 +1,9 @@
+import { shape, string } from 'prop-types';
+
+export const QuizFish = shape({
+    commonName: string.isRequired,
+    scientificName: string.isRequired,
+    picturePath: string.isRequired,
+    videoPath: string.isRequired,
+    hint: string.isRequired,
+});

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -1,6 +1,7 @@
 export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
 export const MAX_IDLE_TIME = 10000; //in ms
+export const GUESS_MESSAGE = 2500; //in ms
 
 export const ABOUT_PROFILES = [
     {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -1,7 +1,7 @@
 export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
 export const MAX_IDLE_TIME = 10000; //in ms
-export const GUESS_MESSAGE = 2500; //in ms
+export const GUESS_MESSAGE_TIME = 2500; //in ms
 
 export const ABOUT_PROFILES = [
     {


### PR DESCRIPTION
## Overview

Add the view that will appear after the user guesses the fish wrong twice or correctly fish during the game. For now, since the quiz isn't exactly built yet, I added 2 demo buttons for guessing. The answers are hard-coded for demonstration.

Using react hooks looked opportune here. They may go away when the quiz is actually built out.

Connects #41

### Demo

![quizguess](https://user-images.githubusercontent.com/10568752/57648603-ebe7f380-7593-11e9-962d-00161ebd9586.gif)

## Testing Instructions

Netlify -> Test your Skills -> Play -> Guess correctly and incorrectly