### PR TITLE
Add button variants and FontAwesome Pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ deployment/terraform/.terraform
 *.tfvars
 *.tfstate*
 *.tfplan
+
+# FontAwesome
+docker-compose.env

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ pin it to a specific version.
     - `package.json`
     - `yarn.lock`
 
+### FontAwesome Pro
+We are using a paid FontAwesome Pro subscription on this project. Please follow the steps below to properly register the imported font styles with FortAwesome:
+1. Add a `.npmrc` file to the same folder as `package.json`.
+2. Paste the following in that file:
+```
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken={AZAVEA_TOKEN}
+```
+3. Replace `{AZAVEA_TOKEN}` with the token visible in FontAwesome’s LastPass notes.
+
 #### Notes
 
 * We usually pin packages to a specific version to minimize build errors.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Install the application and all required dependencies.
 ./scripts/setup
 ```
 
+### Set Environment Variables
+Fishway uses a paid FontAwesome Pro subscription which requires a secret token for use. To configure this, from the project root directory copy the example Docker configuration file:
+
+```sh
+$ cp docker-compose.env.example docker-compose.env
+```
+Open docker-compose.env in a text editor and add the FontAwesome token. Find the token in the Notes section of the FontAwesome entry in LastPass. If using the Lastpass browser extension, "edit" the entry to see the Notes section.
+
 #### Development
 
 Rebuild Docker images and run application.
@@ -61,16 +69,6 @@ pin it to a specific version.
 - Commit the changes to the following files to git:
     - `package.json`
     - `yarn.lock`
-
-### FontAwesome Pro
-We are using a paid FontAwesome Pro subscription on this project. Please follow the steps below to properly register the imported font styles with FortAwesome:
-1. Add a `.npmrc` file to the same folder as `package.json`.
-2. Paste the following in that file:
-```
-@fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken={AZAVEA_TOKEN}
-```
-3. Replace `{AZAVEA_TOKEN}` with the token visible in FontAwesome’s LastPass notes.
 
 #### Notes
 

--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -1,0 +1,2 @@
+#Font Awesome Pro token
+FONT_AWESOME_PRO_TOKEN=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
       - CHOKIDAR_INTERVAL=100
+    env_file: docker-compose.env
     volumes:
         - ./src/app:/usr/src
         - ./src/nginx/srv/dist:/usr/src/static

--- a/scripts/server
+++ b/scripts/server
@@ -19,6 +19,11 @@ then
     then
         usage
     else
+        if [ ! -f docker-compose.env ]
+        then
+            echo "Missing docker env file. Consult project README."
+            exit 1
+        fi
         docker-compose -f docker-compose.yml up
     fi
 fi

--- a/scripts/update
+++ b/scripts/update
@@ -19,6 +19,11 @@ then
     then
         usage
     else
+        if [ ! -f docker-compose.env ]
+        then
+            echo "Missing docker env file. Consult project README."
+            exit 1
+        fi
         # Create dirs expected by docker, if they don't exist
         mkdir -p /vagrant/dist
         mkdir -p /vagrant/src/nginx/srv/dist

--- a/src/app/.gitignore
+++ b/src/app/.gitignore
@@ -21,6 +21,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# for FontAwesome pro
-.npmrc

--- a/src/app/.gitignore
+++ b/src/app/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# for FontAwesome pro
+.npmrc

--- a/src/app/.npmrc
+++ b/src/app/.npmrc
@@ -1,0 +1,2 @@
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=${FONT_AWESOME_PRO_TOKEN}

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -12,6 +12,11 @@
   },
   "dependencies": {
     "@babel/core": "7.2.2",
+    "@fortawesome/fontawesome-svg-core": "1.2.18",
+    "@fortawesome/react-fontawesome": "0.1.4",
+    "@fortawesome/pro-light-svg-icons": "^5.8.2",
+    "@fortawesome/pro-solid-svg-icons": "^5.8.2",
+    "@fortawesome/pro-regular-svg-icons": "^5.8.2",
     "@svgr/webpack": "4.1.0",
     "axios": "~0.18.0",
     "babel-core": "7.0.0-bridge.0",

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -11,6 +11,60 @@ import Quiz from './components/Quiz';
 import GlobalStyle from './util/globalStyle';
 import { RESET, PAUSE, MAX_IDLE_TIME } from './util/constants';
 
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faTimes as falTimes, faCheck } from '@fortawesome/pro-light-svg-icons';
+import {
+    faBullseyePointer,
+    faEye,
+    faInfoCircle,
+    faHome,
+    faTimes,
+    faHistory,
+    faLongArrowRight,
+    faLongArrowLeft,
+    faQuestionCircle,
+    faExclamationCircle,
+    faUndo,
+} from '@fortawesome/pro-regular-svg-icons';
+import {
+    faInfoCircle as fasInfoCircle,
+    faVideo,
+    faVolumeSlash,
+    faVolume,
+    faFish,
+    faPlayCircle,
+    faPauseCircle,
+    faEye as fasEye,
+    faHome as fasHome,
+    faHistory as fasHistory,
+} from '@fortawesome/pro-solid-svg-icons';
+
+library.add(
+    faInfoCircle,
+    fasInfoCircle,
+    faVideo,
+    faFish,
+    faBullseyePointer,
+    faVolumeSlash,
+    faVolume,
+    faPlayCircle,
+    faPauseCircle,
+    faEye,
+    fasEye,
+    faHome,
+    fasHome,
+    faHistory,
+    fasHistory,
+    falTimes,
+    faTimes,
+    faLongArrowRight,
+    faLongArrowLeft,
+    faQuestionCircle,
+    faExclamationCircle,
+    faCheck,
+    faUndo
+);
+
 class App extends Component {
     constructor() {
         super();

--- a/src/app/src/components/Button.js
+++ b/src/app/src/components/Button.js
@@ -1,0 +1,122 @@
+import { Button as BaseButton } from 'rebass';
+import PropTypes from 'prop-types';
+import styled, { css, keyframes } from 'styled-components';
+import {
+    themeGet,
+    style,
+    opacity,
+    letterSpacing,
+    fontFamily,
+} from 'styled-system';
+
+const variant = style({
+    prop: 'variant',
+    cssProperty: 'variant',
+});
+
+const buttonKeyframes = keyframes`
+  0% { background-position: auto auto; }
+  100% { background-position: bottom right; }
+`;
+
+const Button = styled(BaseButton)`
+    font-family: ${props => themeGet(`${props.fontFamily}`, 'font')};
+    transition: all 0.25s;
+    ${opacity};
+    ${letterSpacing};
+
+    &:focus {
+        outline: none;
+    }
+
+    ${props =>
+        props.variant === 'primary' &&
+        css`
+            background-image: linear-gradient(
+                to bottom right,
+                ${themeGet('colors.greens.1')} 0%,
+                ${themeGet('colors.greens.0')} 50%,
+                ${themeGet('colors.greens.2')} 70%,
+                ${themeGet('colors.greens.0')} 100%
+            );
+            background-size: 400% 400%;
+            border: 3px solid ${themeGet('colors.greens.2')};
+            box-shadow: 1px transparent;
+            color: ${themeGet('colors.black')};
+            font-size: ${themeGet('fontSizes.2')};
+            font-weight: ${themeGet('fontWeights.semibold')};
+            text-transform: uppercase;
+            &:active {
+                animation: ${buttonKeyframes} 0.5s linear forwards;
+                box-shadow: inset 0px 0px 1px 3px ${themeGet('colors.greens.0')};
+            }
+        `};
+
+    ${props =>
+        props.variant === 'secondary' &&
+        css`
+            color: ${themeGet('colors.black')};
+            background-image: linear-gradient(
+                to bottom right,
+                ${themeGet('colors.lightblues.2')} 0%,
+                ${themeGet('colors.lightblues.0')} 50%,
+                ${themeGet('colors.lightblues.3')} 70%,
+                ${themeGet('colors.lightblues.0')} 100%
+            );
+            background-size: 400% 400%;
+            box-shadow: 1px transparent;
+            border: 3px solid ${themeGet('colors.lightblues.3')};
+            font-size: ${themeGet('fontSizes.2')};
+            font-weight: ${themeGet('fontWeights.semibold')};
+            text-transform: uppercase;
+            &:active {
+                animation: ${buttonKeyframes} 0.5s linear forwards;
+                box-shadow: inset 0px 0px 1px 3px
+                    ${themeGet('colors.lightblues.0')};
+            }
+        `};
+
+    ${props =>
+        props.variant === 'link' &&
+        css`
+            background: transparent;
+            border: none;
+            font-size: ${themeGet('fontSizes.1')};
+            letter-spacing: 0;
+            font-weight: ${themeGet('fontWeights.normal')};
+            font-style: italic;
+            opacity: 0.8;
+            padding: 0;
+        `};
+    &:active {
+        opacity: 0.5;
+    }
+`;
+
+Button.displayName = 'Button';
+
+Button.propTypes = {
+    variant: PropTypes.string.isRequired,
+};
+
+Button.PropTypes = {
+    ...variant.PropTypes,
+    ...opacity.PropTypes,
+    ...letterSpacing.PropTypes,
+    ...fontFamily.PropTypes,
+};
+
+Button.defaultProps = {
+    as: 'button',
+    color: 'white',
+    lineHeight: 'compact',
+    opacity: '0.9',
+    letterSpacing: 'caps',
+    fontWeight: 'semibold',
+    borderRadius: '15px',
+    px: 'comfortable',
+    py: 'medium',
+    variant: 'primary',
+};
+
+export default Button;

--- a/src/app/src/components/Button.js
+++ b/src/app/src/components/Button.js
@@ -91,6 +91,24 @@ const Button = styled(BaseButton)`
     &:active {
         opacity: 0.5;
     }
+
+    ${props =>
+        props.variant === 'close' &&
+        css`
+            color: ${themeGet('colors.black')};
+            background-color: ${themeGet('colors.white')};
+            box-shadow: 1px transparent;
+            border: 6px solid ${themeGet('colors.teals.3')};
+            font-size: ${themeGet('fontSizes.2')};
+            font-weight: ${themeGet('fontWeights.semibold')};
+            border-radius: 100%;
+            padding: 0;
+            width: 4rem;
+            height: 4rem;
+            &:active {
+                opacity: 0.8;
+            }
+        `};
 `;
 
 Button.displayName = 'Button';

--- a/src/app/src/components/Heading.js
+++ b/src/app/src/components/Heading.js
@@ -1,7 +1,7 @@
 import { Heading as BaseHeading } from 'rebass';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { themeGet, style } from 'styled-system';
+import { themeGet, style, opacity } from 'styled-system';
 
 const variant = style({
     prop: 'variant',
@@ -9,35 +9,29 @@ const variant = style({
 });
 
 const Heading = styled(BaseHeading)`
-    color: ${themeGet('colors.white')};
-    line-height: ${themeGet('lineHeights.normal')};
-
+    ${opacity};
     ${props =>
         props.variant === 'medium' &&
         css`
             font-size: ${themeGet('fontSizes.4')};
-            font-weight: ${themeGet('fontWeights.medium')};
             margin-bottom: ${themeGet('space.medium')};
         `};
     ${props =>
         props.variant === 'base' &&
         css`
             font-size: ${themeGet('fontSizes.3')};
-            font-weight: ${themeGet('fontWeights.semibold')};
             margin-bottom: ${themeGet('space.compact')};
         `};
     ${props =>
         props.variant === 'small' &&
         css`
             font-size: ${themeGet('fontSizes.2')};
-            font-weight: ${themeGet('fontWeights.semibold')};
             margin-bottom: ${themeGet('space.small')};
         `};
     ${props =>
         props.variant === 'xSmall' &&
         css`
             font-size: ${themeGet('fontSizes.1')};
-            font-weight: ${themeGet('fontWeights.semibold')};
             margin-bottom: ${themeGet('space.small')};
             text-transform: uppercase;
             letter-spacing: 1px;
@@ -52,9 +46,14 @@ Heading.propTypes = {
 
 Heading.PropTypes = {
     ...variant.PropTypes,
+    ...opacity.PropTypes,
 };
 
 Heading.defaultProps = {
+    color: 'white',
+    lineHeight: 'normal',
+    fontWeight: 'semibold',
+    opacity: '1',
     variant: 'base',
 };
 

--- a/src/app/src/components/QuizHome.js
+++ b/src/app/src/components/QuizHome.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { func } from 'prop-types';
-import { Flex, Box, Button } from 'rebass';
-import styled from 'styled-components';
+import { Flex, Box } from 'rebass';
+import { Heading, Text, Button } from './custom-styled-components';
 import { themeGet } from 'styled-system';
-
-import { Heading, Text } from './custom-styled-components';
-
+import styled from 'styled-components';
 import { showQuiz } from '../actions';
 
 const StyledQuizHome = styled(Flex)`

--- a/src/app/src/components/QuizNavbar.js
+++ b/src/app/src/components/QuizNavbar.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Flex, Button, Text } from 'rebass';
+import { Flex } from 'rebass';
+import { Heading, Button } from './custom-styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { hideQuiz } from '../actions';
 
@@ -18,10 +20,12 @@ const QuizNavbar = props => {
     const { dispatch } = props;
     return (
         <StyledQuizNavbar>
-            <Text as='h5' fontSize='0'>
+            <Heading as='h1' variant='xSmall' fontSize='0'>
                 TEST YOUR SKILLS
-            </Text>
-            <Button onClick={() => dispatch(hideQuiz())}>x</Button>
+            </Heading>
+            <Button variant='close' onClick={() => dispatch(hideQuiz())}>
+                <FontAwesomeIcon icon={['fal', 'times']} />
+            </Button>
         </StyledQuizNavbar>
     );
 };

--- a/src/app/src/components/Screensaver.js
+++ b/src/app/src/components/Screensaver.js
@@ -26,7 +26,8 @@ const Screensaver = props => {
                     as='h1'
                     variant='medium'
                     textShadow='large'
-                    opacity='0.95'
+                    fontWeight='medium'
+                    opacity={0.9}
                 >
                     Learn how the fish ladder helps fish populations and whether
                     you have what it takes to be an aquatic biologist.

--- a/src/app/src/components/Screensaver.js
+++ b/src/app/src/components/Screensaver.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { func } from 'prop-types';
 import styled from 'styled-components';
-import { Flex, Box, Button } from 'rebass';
-import { Heading } from './custom-styled-components';
+import { Flex, Box } from 'rebass';
+import { Heading, Button } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 
 import { hideScreensaver } from '../actions';
@@ -32,7 +32,7 @@ const Screensaver = props => {
                     Learn how the fish ladder helps fish populations and whether
                     you have what it takes to be an aquatic biologist.
                 </Heading>
-                <Button>Let's go!</Button>
+                <Button>Let’s go!</Button>
             </Box>
         </StyledScreensaver>
     );

--- a/src/app/src/components/Text.js
+++ b/src/app/src/components/Text.js
@@ -1,7 +1,7 @@
 import { Text as BaseText } from 'rebass';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { themeGet, style } from 'styled-system';
+import { themeGet, style, opacity } from 'styled-system';
 
 const variant = style({
     prop: 'variant',
@@ -9,12 +9,7 @@ const variant = style({
 });
 
 const Text = styled(BaseText)`
-    color: ${themeGet('colors.white')};
-    font-weight: ${themeGet('fontWeights.normal')};
-    line-height: ${themeGet('lineHeights.normal')};
-    margin-bottom: ${themeGet('space.small')};
-    opacity: 0.8;
-
+    ${opacity};
     ${props =>
         props.variant === 'large' &&
         css`
@@ -41,9 +36,15 @@ Text.propTypes = {
 
 Text.PropTypes = {
     ...variant.PropTypes,
+    ...opacity.PropTypes,
 };
 
 Text.defaultProps = {
+    color: 'white',
+    fontWeight: 'normal',
+    lineHeight: 'normal',
+    mb: 'small',
+    opacity: '0.8',
     variant: 'base',
 };
 

--- a/src/app/src/components/custom-styled-components.js
+++ b/src/app/src/components/custom-styled-components.js
@@ -1,2 +1,3 @@
+export { default as Button } from './Button';
 export { default as Heading } from './Heading';
 export { default as Text } from './Text';

--- a/src/app/src/util/globalStyle.js
+++ b/src/app/src/util/globalStyle.js
@@ -72,8 +72,13 @@ const GlobalStyle = createGlobalStyle`
        font-size: 16px;
        font-family: Fira Sans, Helvetica, Arial, sans-serif;
     }
+
     body {
        line-height: 1;
+    }
+    
+    *::selection {
+        background: transparent;
     }
 
     #root, 

--- a/src/app/src/util/theme.js
+++ b/src/app/src/util/theme.js
@@ -4,6 +4,7 @@ export default {
         medium: '52em',
         large: '64em',
     },
+    font: 'Fira Sans, Helvetica, Arial, sans-serif',
     fontSizes: [
         '1rem', // 0
         '1.2rem', // 1
@@ -25,10 +26,14 @@ export default {
         normal: '1.25',
         comfortable: '1.85',
     },
+    letterSpacings: {
+        0: '0',
+        caps: '2px',
+    },
     colors: {
         white: '#fff',
-        lightblue: '#E7FDFF',
-        greens: ['#e9f563', '#CEE007'],
+        lightblues: ['#d1f0f3', '#E7FDFF', '#a5dde2', '#84bdc2'],
+        greens: ['#e9f563', '#CEE007', '#c1d12f', '#a0af04'],
         red: '#C5603B',
         teals: [
             '#296882',

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -984,6 +984,47 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
   integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
 
+"@fortawesome/fontawesome-common-types@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz#c0d8f073a5116b2de0a2c8a7aba66093a6956ce7"
+  integrity sha512-834DrzO2Ne3upCW+mJJPC/E6BsFcj+2Z1HmPIhbpbj8UaKmXWum4NClqLpUiMetugRlHuG4jbIHNdv2/lc3c1Q==
+
+"@fortawesome/fontawesome-svg-core@1.2.18":
+  version "1.2.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.18.tgz#c26cbded461895ebe260f0dea771ca29d8cb3517"
+  integrity sha512-1vyLWVQqxQ8q8bA2zgZcljk3RkeELlDJ757ymLk+ebK019AFgEFH5kTnR5OMN1SFsTwW1OHlFQO3VufdeCg/Gg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
+
+"@fortawesome/pro-light-svg-icons@^5.8.2":
+  version "5.8.2"
+  resolved "https://npm.fontawesome.com/@fortawesome/pro-light-svg-icons/-/pro-light-svg-icons-5.8.2.tgz#c181c7a97f207ccfba929489a2a87f9a5e9f4865"
+  integrity sha512-sdJgFDno6xLsfJ1UV6yFaahNZYpPjJwJaXr9BuxryLTtgwgIszeTl5FEWm7Xf7cAt+3akdRjUqjYXdBmUm+q+A==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
+
+"@fortawesome/pro-regular-svg-icons@^5.8.2":
+  version "5.8.2"
+  resolved "https://npm.fontawesome.com/@fortawesome/pro-regular-svg-icons/-/pro-regular-svg-icons-5.8.2.tgz#03fbe2f52a1f3050df3a0dd0c13a10875fd58bff"
+  integrity sha512-cCfhBrDlrMxmWQgTsdmux8iYR1q0x1MLhZbsC25TOxf1woX1YOO/j0aZ5m/wfLhK++nCUawNZzOePUNl9fCUkQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
+
+"@fortawesome/pro-solid-svg-icons@^5.8.2":
+  version "5.8.2"
+  resolved "https://npm.fontawesome.com/@fortawesome/pro-solid-svg-icons/-/pro-solid-svg-icons-5.8.2.tgz#6e1ce9e8f4202b3b378ff4a28a35503c1987bfc6"
+  integrity sha512-raU7P+5OJ4MXJmsnssFfoT8SCiwS68ce8HocIin2qS7/0NEV0ETenLOIGPD5+5CKCrM/dLnf0S7fdAWlrlYYLw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
+
+"@fortawesome/react-fontawesome@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz#18d61d9b583ca289a61aa7dccc05bd164d6bc9ad"
+  integrity sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==
+  dependencies:
+    humps "^2.0.1"
+    prop-types "^15.5.10"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -5186,6 +5227,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+  integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
+
 husky@^1.2.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/husky/-/husky-1.3.1.tgz#26823e399300388ca2afff11cfa8a86b0033fae0"
@@ -8940,7 +8986,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^3.0.0"
 
-prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
## Overview
This PR tackles adding our button styles to the app:
- Primary (green, default)
- Secondary (sky blue)
- Close (white)
- Link

FontAwesome Pro has also been added to the app, but we will need to follow up with #64 so that it works with Netlify previews.

Connects #49, connects #61 

### Demo
Primary
<img width="1792" alt="Screen Shot 2019-05-13 at 4 45 39 PM" src="https://user-images.githubusercontent.com/5672295/57654023-3de34600-75a1-11e9-8168-5f642d8a47cb.png">
Primary on hover
![button-on-click](https://user-images.githubusercontent.com/5672295/57654033-42a7fa00-75a1-11e9-8553-964d4161ba4a.gif)
Secondary
<img width="442" alt="Screen Shot 2019-05-13 at 4 48 05 PM" src="https://user-images.githubusercontent.com/5672295/57654053-4d628f00-75a1-11e9-8537-2cef8002ce81.png">
Close icon
<img width="1679" alt="Screen Shot 2019-05-13 at 4 47 13 PM" src="https://user-images.githubusercontent.com/5672295/57654052-4d628f00-75a1-11e9-951e-3eb279a06d63.png">
Link
<img width="277" alt="Screen Shot 2019-05-13 at 5 05 39 PM" src="https://user-images.githubusercontent.com/5672295/57654100-69663080-75a1-11e9-9651-02fa75005e50.png">

### Notes
- While doing this, I cleaned up how I was handling Header and Text props, so pushed some styles to `defaultProps`. Now that this isn't being explicitly stated in the `variant`, we can more easily override things like color (this will be more relevant when we make the modal).
- We don't need to add buttons that specifically deal with icons (yay!) We get a lot of stuff for free from the imported `<FontAwesomeIcon>` component, including the ability to add the proper padding to a icon button with `pull: left|right`. Using this prop, we can make the following monstrosity:
![Screen Shot 2019-05-13 at 3 29 55 PM](https://user-images.githubusercontent.com/5672295/57654253-b944f780-75a1-11e9-97d5-df3580f68116.png) More [here.](https://www.npmjs.com/package/@fortawesome/react-fontawesome#basic)


## Testing Instructions
* `git pull`
* Follow the new README instructions for adding a FontAwesome Pro token to the project.
* `./scripts/update`
* Look at Screensaver, and note that the default button is a Primary style. 
* Add `variant='secondary'` to the Screensaver button. Note that it is now the Secondary style.
* Add `variant='link`.
* Go to "Test your skills" and click the Play button. Note the Close button in the top right.
