### PR TITLE
Format fishway sidebar date

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -49,6 +49,7 @@
     "jest-watch-typeahead": "^0.2.1",
     "leaflet": "~1.3.1",
     "mini-css-extract-plugin": "0.5.0",
+    "moment": "^2.24.0",
     "nuka-carousel": "~4.5.4",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.2.1",

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Box } from 'rebass';
 import { Heading, Text } from './custom-styled-components';
 import { themeGet } from 'styled-system';
+import moment from 'moment';
 
 import { HighlightFish } from '../util/HighlightFish';
 
@@ -16,7 +17,9 @@ const StyledSidebar = styled(Box)`
 
 const Sidebar = ({ fish }) => {
     const { commonName, scientificName, path, notes, timestamp } = fish;
-    const date = new Date(timestamp).toLocaleString();
+    const date = moment(timestamp)
+        .format('MMMM Do')
+        .toUpperCase();
     const video = fish && (
         <Video src={`${path}.mp4`} autoPlay={true} setref={null} />
     );

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -7290,6 +7290,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
## Overview

Brings in moment.js to format the fishway sidebar date as specified in the design.

Connects #71 

### Demo

![image](https://user-images.githubusercontent.com/1042475/58120697-c1b9b580-7bd3-11e9-9bb8-ce336bb6fb79.png)

### Notes

I decided against manually formatting the dates in the constants file because 1) it seemed like more work,  2) if the dates change, we'll have to format them again, and 3) if the format changes, updating all of the dates manually will take more time than updating the moment format string.

## Testing Instructions

- Run `./scripts/update` to install the new package.
- Visit the "See the fishway" page, and verify the dates are formatted correctly.