### PR TITLE
Style Navbar component

### DIFF
--- a/src/app/src/components/Navbar.js
+++ b/src/app/src/components/Navbar.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import Tabs from 'react-bootstrap/Tabs';
 import Tab from 'react-bootstrap/Tab';
+import { Heading } from './custom-styled-components';
 import styled from 'styled-components';
+import { themeGet } from 'styled-system';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import About from './About';
 import SeeTheFishway from './SeeTheFishway';
@@ -12,6 +15,58 @@ const StyledTabs = styled(Tabs)`
     width: 100%;
     display: flex;
     justify-content: space-evenly;
+    align-items: center;
+    height: 5rem;
+    border-bottom: 1px solid ${themeGet('colors.teals.1')};
+    background: ${themeGet('colors.teals.3')};
+
+    .nav-item {
+        text-decoration: none;
+        position: relative;
+        display: flex;
+        align-items: flex-end;
+        transition: opacity 0.75s ease-in;
+
+        span {
+            margin-bottom: 0;
+            line-height: 1.5;
+        }
+
+        &::after {
+            content: '';
+            display: block;
+            position: absolute;
+            left: 0;
+            right: 0;
+            bottom: -27px;
+            height: 2px;
+            background: right center / 250%
+                linear-gradient(
+                    to right,
+                    ${themeGet('colors.lightblues.0')} 0 20%,
+                    ${themeGet('colors.lightblues.1')} 25% 50%,
+                    transparent 50% 100%
+                );
+            border-radius: 2px;
+            opacity: 0;
+            transition: background-position 0.25s ease-in,
+                opacity 0.25s 0.05s ease-in;
+        }
+    }
+
+    .nav-item:focus {
+        outline: none;
+    }
+
+    .active span,
+    .active svg {
+        opacity: 1;
+    }
+
+    .active::after {
+        background-position: left center;
+        opacity: 1;
+    }
 `;
 
 const StyledNavbar = styled.div`
@@ -19,21 +74,68 @@ const StyledNavbar = styled.div`
 `;
 
 const Navbar = props => {
+    const titles = {
+        about: (
+            <Heading as='span' variant='xSmall' opacity='0.8'>
+                <FontAwesomeIcon
+                    icon={['fas', 'info-circle']}
+                    pull='left'
+                    opacity='0.8'
+                    size='lg'
+                />
+                About
+            </Heading>
+        ),
+        seeTheFishway: (
+            <Heading as='span' variant='xSmall' opacity='0.8'>
+                <FontAwesomeIcon
+                    icon={['fas', 'video']}
+                    pull='left'
+                    opacity='0.8'
+                    size='lg'
+                />
+                See the Fishway
+            </Heading>
+        ),
+        meetTheFish: (
+            <Heading as='span' variant='xSmall' opacity='0.8'>
+                <FontAwesomeIcon
+                    icon={['fas', 'fish']}
+                    pull='left'
+                    opacity='0.8'
+                    size='lg'
+                />
+                Meet the Fish
+            </Heading>
+        ),
+        testYourSkills: (
+            <Heading as='span' variant='xSmall' opacity='0.8'>
+                <FontAwesomeIcon
+                    icon={['far', 'bullseye-pointer']}
+                    pull='left'
+                    opacity='0.8'
+                    size='lg'
+                />
+                Test your Skills
+            </Heading>
+        ),
+    };
+
     return (
         <StyledNavbar hide={props.isQuizVisible ? 'none' : 'visible'}>
             {/* unmountOnExit is used to ensure that videos restart when
             switching from About tab to another tab and back again */}
             <StyledTabs defaultActiveKey='about' unmountOnExit={true}>
-                <Tab eventKey='about' title='About'>
+                <Tab eventKey='about' title={titles.about}>
                     <About />
                 </Tab>
-                <Tab eventKey='see' title='See the Fishway'>
+                <Tab eventKey='see' title={titles.seeTheFishway}>
                     <SeeTheFishway />
                 </Tab>
-                <Tab eventKey='meet' title='Meet the Fish'>
+                <Tab eventKey='meet' title={titles.meetTheFish}>
                     <MeetTheFish />
                 </Tab>
-                <Tab eventKey='test' title='Test your Skills'>
+                <Tab eventKey='test' title={titles.testYourSkills}>
                     <QuizHome />
                 </Tab>
             </StyledTabs>


### PR DESCRIPTION
## Overview
Adds basic styling to `Navbar` component. 

Connects #67

### Demo
![Screen Shot 2019-05-21 at 3 33 18 PM](https://user-images.githubusercontent.com/5672295/58125147-e4e96280-7bdd-11e9-9d95-03a3708fb98b.png)

Animation upon click
![fishway_navbar](https://user-images.githubusercontent.com/5672295/58125175-f9c5f600-7bdd-11e9-8901-3f2120312388.gif)


### Notes
- I added a temporary background color and border color so we can see the links, but will need to revisit when working on #66.
- Using `react-bootstrap` gets a little hairy since they want you to style with classnames. It's definitely a bit of a departure from how we're handling other styles, and open to ideas for how to make this nicer.
- We will need to animate the `Navbar` into the screen when the `Screensaver` component disappears and `Quiz` component appears. I'll make a new issue for this since I want to tackle it after the background is implemented.

## Testing Instructions
* `git pull` 
* Click "Let's go" button
* Click on each navigation `Tab` to see the animation.
