### PR TITLE
Add custom mute button to slide videos

### DIFF
--- a/src/app/src/components/AboutSlide.js
+++ b/src/app/src/components/AboutSlide.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Button, Flex } from 'rebass';
 import { Heading, Text } from './custom-styled-components';
 import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import Video from './Video';
 
@@ -30,14 +31,23 @@ const PlayButton = styled(Button)`
     text-align: center;
 `;
 
+const MuteButton = styled(Button)`
+    background: none;
+    height: 50px;
+    width: 50px;
+    text-align: center;
+    position: absolute;
+    bottom: 50px;
+`;
+
 export default class AboutSlide extends Component {
     constructor(props) {
         super(props);
         this.state = {
             playing: true,
+            muted: false,
         };
         this.videoRef = React.createRef();
-        this.togglePlayPause = this.togglePlayPause.bind(this);
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -58,12 +68,18 @@ export default class AboutSlide extends Component {
         }
     }
 
-    togglePlayPause() {
+    togglePlayPause = () => {
         this.setState({ playing: !this.state.playing });
-    }
+    };
+
+    toggledMuted = () => {
+        this.setState({ muted: !this.state.muted });
+    };
 
     render() {
         const { active, description, job, name, title, videoPath } = this.props;
+        const muteIcon = this.state.muted ? 'volume' : 'volume-slash';
+        const muteIconColor = this.state.muted ? '#fff' : '#666';
 
         return (
             <StyledAboutSlide>
@@ -73,12 +89,19 @@ export default class AboutSlide extends Component {
                         autoPlay={active}
                         src={videoPath}
                         onClick={this.togglePlayPause}
+                        muted={this.state.muted}
                     />
                     {!this.state.playing && (
                         <PlayButton onClick={this.togglePlayPause}>
                             ▶
                         </PlayButton>
                     )}
+                    <MuteButton
+                        onClick={this.toggledMuted}
+                        color={muteIconColor}
+                    >
+                        <FontAwesomeIcon icon={['fa', muteIcon]} />
+                    </MuteButton>
                 </Flex>
                 <Flex
                     width={2 / 5}

--- a/src/app/src/components/AboutSlide.js
+++ b/src/app/src/components/AboutSlide.js
@@ -1,20 +1,29 @@
 import React, { Component } from 'react';
-import { Button, Flex } from 'rebass';
-import { Heading, Text } from './custom-styled-components';
+import { Flex } from 'rebass';
+import { Heading, Text, Button } from './custom-styled-components';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { themeGet } from 'styled-system';
 
 import Video from './Video';
 
 const StyledAboutSlide = styled(Flex)`
     height: 80vh;
     padding: 1rem;
+    align-items: center;
 
     video {
         margin: auto;
         height: fit-content;
         max-width: 100%;
     }
+`;
+
+const VideoContainer = styled(Flex)`
+    position: relative;
+    padding: 2px;
+    border: 1px solid ${themeGet('colors.teals.3')};
+    background: ${themeGet('colors.teals.6')};
 `;
 
 const PlayButton = styled(Button)`
@@ -32,12 +41,9 @@ const PlayButton = styled(Button)`
 `;
 
 const MuteButton = styled(Button)`
-    background: none;
-    height: 50px;
-    width: 50px;
-    text-align: center;
     position: absolute;
-    bottom: 50px;
+    bottom: 0.75rem;
+    left: 1rem;
 `;
 
 export default class AboutSlide extends Component {
@@ -83,7 +89,7 @@ export default class AboutSlide extends Component {
 
         return (
             <StyledAboutSlide>
-                <Flex width={3 / 5}>
+                <VideoContainer width={3 / 5}>
                     <Video
                         setref={this.videoRef}
                         autoPlay={active}
@@ -97,12 +103,13 @@ export default class AboutSlide extends Component {
                         </PlayButton>
                     )}
                     <MuteButton
+                        variant='link'
                         onClick={this.toggledMuted}
                         color={muteIconColor}
                     >
                         <FontAwesomeIcon icon={['fa', muteIcon]} />
                     </MuteButton>
-                </Flex>
+                </VideoContainer>
                 <Flex
                     width={2 / 5}
                     padding='2rem'

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -1,6 +1,6 @@
 export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
-export const MAX_IDLE_TIME = 10000; //in ms
+export const MAX_IDLE_TIME = 100000000; //in ms
 export const GUESS_MESSAGE_TIME = 2500; //in ms
 
 export const ABOUT_PROFILES = [

--- a/src/app/src/util/theme.js
+++ b/src/app/src/util/theme.js
@@ -42,6 +42,7 @@ export default {
             '#163846',
             '#112c37',
             '#0d2029',
+            '#010d13',
         ],
         xlighttan: '#fffdf9',
         lighttan: '#FBF8F4',


### PR DESCRIPTION
## Overview

Adds a mute button using the FontAwesome icon specified in the designs.

Connects #34 

### Demo

![May-21-2019 15-43-32](https://user-images.githubusercontent.com/1042475/58125806-7a392680-7bdf-11e9-95f6-d38a2522948b.gif)

### Notes

This will need some styling improvements @alexelash. I had trouble getting it positioned like in the designs.

## Testing Instructions

- Visit the about page.
- Verify there is a mute button for each video.
- Click a mute button, verify it changes to white when its active and mutes the corresponding video.