### PR TITLE
Implement reel of fish on Meet the Fish

### DIFF
--- a/src/app/src/components/MeetTheFish.js
+++ b/src/app/src/components/MeetTheFish.js
@@ -11,6 +11,11 @@ const StyledMeetTheFish = styled(Flex)`
     justify-content: center;
     text-align: center;
     flex-direction: column;
+    width: 100%;
+`;
+
+const Header = styled(Box)`
+    margin: 50px auto;
 `;
 
 const FishButton = styled.button`
@@ -19,17 +24,22 @@ const FishButton = styled.button`
 `;
 
 const FishImage = styled.img`
-    max-width: 350px;
-    max-height: 300px;
+    max-width: 400px;
+    max-height: 350px;
 `;
 
-const FishReel = styled(Flex)`
+const FishReelContainer = styled(Box)`
+    width: 100%;
     overflow-x: scroll;
-    -webkit-overflow-scrolling: touch;
 
     ::-webkit-scrollbar {
         display: none;
     }
+`;
+
+const FishReel = styled(Flex)`
+    flex-wrap: wrap;
+    width: 380%;
 `;
 
 const MeetTheFish = () => {
@@ -42,14 +52,16 @@ const MeetTheFish = () => {
     ));
     return (
         <StyledMeetTheFish>
-            <Box>
+            <Header>
                 <Heading as='h1'>Meet the Fish</Heading>
                 <Text as='p' variant='large' padding='0 400px'>
                     Did you know over 48 species of fish live in the waterways
                     of Philadelphia? Here are 24 of the most common species.
                 </Text>
-            </Box>
-            <FishReel>{buttons}</FishReel>
+            </Header>
+            <FishReelContainer>
+                <FishReel>{buttons}</FishReel>
+            </FishReelContainer>
         </StyledMeetTheFish>
     );
 };

--- a/src/app/src/components/MeetTheFish.js
+++ b/src/app/src/components/MeetTheFish.js
@@ -1,28 +1,55 @@
 import React from 'react';
-import { Box, Button, Flex } from 'rebass';
+import { Box, Flex } from 'rebass';
 import styled from 'styled-components';
 
 import { Heading, Text } from './custom-styled-components';
 import MeetTheFishModal from './MeetTheFishModal';
 
+import { FISH } from '../util/constants';
+
 const StyledMeetTheFish = styled(Flex)`
     justify-content: center;
     text-align: center;
+    flex-direction: column;
+`;
+
+const FishButton = styled.button`
+    background-color: transparent;
+    border: none;
+`;
+
+const FishImage = styled.img`
+    max-width: 350px;
+    max-height: 300px;
+`;
+
+const FishReel = styled(Flex)`
+    overflow-x: scroll;
+    -webkit-overflow-scrolling: touch;
+
+    ::-webkit-scrollbar {
+        display: none;
+    }
 `;
 
 const MeetTheFish = () => {
+    const buttons = FISH.map((fish, idx) => (
+        <MeetTheFishModal index={idx}>
+            <FishButton>
+                <FishImage src={fish.picturePath} />
+            </FishButton>
+        </MeetTheFishModal>
+    ));
     return (
         <StyledMeetTheFish>
-            <Box width={1 / 2}>
+            <Box>
                 <Heading as='h1'>Meet the Fish</Heading>
-                <Text as='p' variant='large'>
+                <Text as='p' variant='large' padding='0 400px'>
                     Did you know over 48 species of fish live in the waterways
                     of Philadelphia? Here are 24 of the most common species.
                 </Text>
-                <MeetTheFishModal index={0}>
-                    <Button>Meet a fish!</Button>
-                </MeetTheFishModal>
             </Box>
+            <FishReel>{buttons}</FishReel>
         </StyledMeetTheFish>
     );
 };

--- a/src/app/src/components/MeetTheFish.js
+++ b/src/app/src/components/MeetTheFish.js
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Flex } from 'rebass';
 import styled from 'styled-components';
 
 import { Heading, Text } from './custom-styled-components';
+import MeetTheFishButton from './MeetTheFishButton';
 import MeetTheFishModal from './MeetTheFishModal';
 
-import { FISH } from '../util/constants';
+import { FISH, FISH_MODAL_OPEN_DELAY } from '../util/constants';
 
 const StyledMeetTheFish = styled(Flex)`
     justify-content: center;
@@ -15,52 +16,72 @@ const StyledMeetTheFish = styled(Flex)`
 `;
 
 const Header = styled(Box)`
-    margin: 50px auto;
+    margin-top: 50px;
 `;
 
-const FishButton = styled.button`
-    background-color: transparent;
-    border: none;
-`;
-
-const FishImage = styled.img`
-    max-width: 400px;
-    max-height: 350px;
+const Subtitle = styled(Text)`
+    padding: 0 300px;
 `;
 
 const FishReelContainer = styled(Box)`
     width: 100%;
     overflow-x: scroll;
+    padding-left: 100px;
 
     ::-webkit-scrollbar {
         display: none;
     }
 `;
 
+const FishButtonAndModal = styled(Box)`
+    padding: 20px;
+`;
+
 const FishReel = styled(Flex)`
     flex-wrap: wrap;
-    width: 380%;
+    width: 400%;
 `;
 
 const MeetTheFish = () => {
-    const buttons = FISH.map((fish, idx) => (
-        <MeetTheFishModal index={idx}>
-            <FishButton>
-                <FishImage src={fish.picturePath} />
-            </FishButton>
-        </MeetTheFishModal>
+    const [selectedFish, setSelectedFish] = useState(null);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const onModalClose = () => {
+        setIsModalOpen(false);
+        setSelectedFish(null);
+    };
+
+    const onButtonClick = idx => {
+        setSelectedFish(idx);
+        setTimeout(() => setIsModalOpen(true), FISH_MODAL_OPEN_DELAY);
+    };
+
+    const fishButtons = FISH.map((fish, idx) => (
+        <FishButtonAndModal key={fish.commonName}>
+            <MeetTheFishButton
+                fish={fish}
+                onButtonClick={onButtonClick}
+                index={idx}
+                disabled={selectedFish ? true : false}
+            />
+            <MeetTheFishModal
+                index={idx}
+                open={selectedFish === idx && isModalOpen ? true : false}
+                onModalClose={onModalClose}
+            />
+        </FishButtonAndModal>
     ));
     return (
         <StyledMeetTheFish>
             <Header>
                 <Heading as='h1'>Meet the Fish</Heading>
-                <Text as='p' variant='large' padding='0 400px'>
+                <Subtitle as='p' variant='large'>
                     Did you know over 48 species of fish live in the waterways
                     of Philadelphia? Here are 24 of the most common species.
-                </Text>
+                </Subtitle>
             </Header>
             <FishReelContainer>
-                <FishReel>{buttons}</FishReel>
+                <FishReel>{fishButtons}</FishReel>
             </FishReelContainer>
         </StyledMeetTheFish>
     );

--- a/src/app/src/components/MeetTheFishButton.js
+++ b/src/app/src/components/MeetTheFishButton.js
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { func, number, bool } from 'prop-types';
+
+import { Heading, Text } from './custom-styled-components';
+import { CatalogFish } from '../util/CatalogFish';
+import { FISH_MODAL_OPEN_DELAY } from '../util/constants';
+
+const FishImage = styled.img`
+    max-width: 400px;
+    max-height: 450px;
+    transition: transform 0.5s linear;
+
+    &.large {
+        transform: scale(1.5);
+    }
+`;
+
+const FishButton = styled.button`
+    background-color: transparent;
+    border: none;
+
+    :focus {
+        outline: none;
+    }
+`;
+
+const MeetTheFishButton = ({ fish, index, disabled, onButtonClick }) => {
+    const [isFishLarge, setIsFishLarge] = useState(false);
+
+    const caption = (
+        <Heading as='h2' variant='small'>
+            {fish.commonName}
+            <Text variant='small'>{fish.scientificName}</Text>
+        </Heading>
+    );
+
+    const onFishClicked = () => {
+        setIsFishLarge(true);
+        setTimeout(() => setIsFishLarge(false), FISH_MODAL_OPEN_DELAY);
+    };
+
+    return (
+        <>
+            <FishButton
+                key={fish.commonName}
+                onClick={() => {
+                    onFishClicked();
+                    onButtonClick(index);
+                }}
+                disabled={disabled}
+            >
+                <FishImage
+                    src={fish.picturePath}
+                    className={isFishLarge && 'large'}
+                    alt={fish.commonName}
+                />
+                {caption}
+            </FishButton>
+        </>
+    );
+};
+
+MeetTheFishButton.propTypes = {
+    fish: CatalogFish.isRequired,
+    index: number.isRequired,
+    onButtonClick: func.isRequired,
+    disabled: bool.isRequired,
+};
+
+export default MeetTheFishButton;

--- a/src/app/src/components/MeetTheFishButton.js
+++ b/src/app/src/components/MeetTheFishButton.js
@@ -9,7 +9,7 @@ import { FISH_MODAL_OPEN_DELAY } from '../util/constants';
 const FishImage = styled.img`
     max-width: 400px;
     max-height: 450px;
-    transition: transform 0.5s linear;
+    transition: transform 1s linear;
 
     &.large {
         transform: scale(1.5);

--- a/src/app/src/components/MeetTheFishModal.js
+++ b/src/app/src/components/MeetTheFishModal.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { func, bool, number } from 'prop-types';
 import Popup from 'reactjs-popup';
 import { Box, Button, Flex, Link } from 'rebass';
 import styled from 'styled-components';
@@ -95,7 +96,7 @@ export default class MeetTheFishModal extends Component {
         );
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate(_, prevState) {
         if (
             prevState.index !== this.state.index &&
             this.overviewRef.current !== null
@@ -105,7 +106,7 @@ export default class MeetTheFishModal extends Component {
     }
 
     render() {
-        const { children } = this.props;
+        const { open, onModalClose } = this.props;
 
         const fish = FISH[this.state.index];
 
@@ -133,10 +134,13 @@ export default class MeetTheFishModal extends Component {
 
         return (
             <StyledPopup
-                trigger={children}
+                open={open}
                 modal
                 closeOnDocumentClick
-                onClose={() => this.setState({ index: this.props.index })}
+                onClose={() => {
+                    this.setState({ index: this.props.index });
+                    onModalClose();
+                }}
             >
                 {close => (
                     <ModalContainer>
@@ -213,3 +217,9 @@ export default class MeetTheFishModal extends Component {
         );
     }
 }
+
+MeetTheFishModal.propTypes = {
+    open: bool.isRequired,
+    index: number.isRequired,
+    onModalClose: func.isRequired,
+};

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -75,7 +75,7 @@ export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
 export const MAX_IDLE_TIME = 180000; //in ms, should be 180000 (3 minutes)
 export const GUESS_MESSAGE_TIME = 2500; //in ms, should be 2500
-export const FISH_MODAL_OPEN_DELAY = 1500; //in ms, should be 1500
+export const FISH_MODAL_OPEN_DELAY = 1000; //in ms, should be 1000
 
 export const ABOUT_PROFILES = [
     {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -73,8 +73,8 @@ import schuylkillVideo from '../media/about/schuylkill.mp4';
 
 export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
-export const MAX_IDLE_TIME = 100000000; //in ms
-export const GUESS_MESSAGE_TIME = 2500; //in ms
+export const MAX_IDLE_TIME = 180000; //in ms, should be 180000 (3 minutes)
+export const GUESS_MESSAGE_TIME = 2500; //in ms, should be 2500
 
 export const ABOUT_PROFILES = [
     {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -128,7 +128,7 @@ const QUILLBACK = {
 };
 
 const STRIPED_BASS_COMMON_NAME = 'Striped Bass';
-const STRIPED_BASS_SCIENTIFIC_NAME = 'Striped Bass';
+const STRIPED_BASS_SCIENTIFIC_NAME = 'Morone saxatilis';
 const STRIPED_BASS = {
     commonName: STRIPED_BASS_COMMON_NAME,
     scientificName: STRIPED_BASS_SCIENTIFIC_NAME,

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -75,6 +75,7 @@ export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
 export const MAX_IDLE_TIME = 180000; //in ms, should be 180000 (3 minutes)
 export const GUESS_MESSAGE_TIME = 2500; //in ms, should be 2500
+export const FISH_MODAL_OPEN_DELAY = 1500; //in ms, should be 1500
 
 export const ABOUT_PROFILES = [
     {


### PR DESCRIPTION
## Overview

We had the modal on this tab with a dummy button that opened the modal at a given index. This PR builds out the rest of Meet The Fish's major logic which is a swipeable reel of fish buttons that open the modal at said fish.

As [per behavior comments](https://share.goabstract.com/b878f89a-ac58-42ca-b7ad-63e0df8f3945) in the wireframes, the fish grow in size upon click and the modal opens after that animation.

I chatted with @alexelash offline and we decided that because the fish look quite similar, the fish name text should always show unlike in the wireframes. Also, there is purposefully no fish animation when the modal is closed. The fish are all returned to normal size.

Connects #73, #86 

### Demo

The scroll:
![fish scroll](https://user-images.githubusercontent.com/10568752/58914248-0113f600-86ec-11e9-95d5-c6658088db4c.gif)

Opening a modal on a fish:
![open_fish_modal](https://user-images.githubusercontent.com/10568752/58914268-1426c600-86ec-11e9-9272-47b51389211d.gif)


### Notes

The fish buttons are disabled while a fish is selected.

The styling is a bit hard-coded in terms of how big the fish are, which determines how they fill the page. We want two equal-ish rows. We don't have the ELO monitor yet so I used landscape ipad pro mode on Chrome. Will require adjustment later.

The fish buttons include the rectangular area around the actual fish image, which I think is probably good for ease of use. We can test that hypothesis later!

## Testing Instructions

The styling is optimized for ipad pro landscape mode on chrome. Open your browser to these settings and visit the Meet the Fish tab and play around. Try to break it! Pick long fish, tall fish..
