### PR TITLE
Style About Tab

### DIFF
--- a/src/app/src/components/About.js
+++ b/src/app/src/components/About.js
@@ -14,7 +14,7 @@ import { ABOUT_PROFILES } from '../util/constants';
 import AboutSlide from './AboutSlide';
 
 // Amounts greater than 1 indicate how much of the surrounding slides to show
-const slidesToShow = 1.3;
+const slidesToShow = 1;
 
 const StyledAbout = styled(Flex)`
     height: calc(100vh - 5rem);

--- a/src/app/src/components/About.js
+++ b/src/app/src/components/About.js
@@ -1,10 +1,12 @@
 import Carousel from 'nuka-carousel';
+import { Flex } from 'rebass';
 import { PagingDots } from 'nuka-carousel/lib';
 import { func, number } from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { Heading } from './custom-styled-components';
+import { themeGet } from 'styled-system';
 
 import { saveAboutSlideIndex, resetTimer } from '../actions';
 import { ABOUT_PROFILES } from '../util/constants';
@@ -14,12 +16,45 @@ import AboutSlide from './AboutSlide';
 // Amounts greater than 1 indicate how much of the surrounding slides to show
 const slidesToShow = 1.3;
 
-const StyledAbout = styled.div`
-    padding-top: 1rem;
+const StyledAbout = styled(Flex)`
+    height: calc(100vh - 5rem);
+    flex-direction: column;
+    justify-content: center;
 
-    .about__slide {
-        height: 80vh;
-        padding: 1rem;
+    .slider {
+        padding-top: 2rem;
+    }
+
+    .slider-slide {
+        opacity: 0.25;
+        transition: opacity 0.25s;
+    }
+
+    .slide-visible {
+        opacity: 1;
+    }
+
+    .paging-item button:focus {
+        outline: none;
+    }
+
+    .paging-dot {
+        background: ${themeGet('colors.teals.2')}!important;
+        width: 14px !important;
+        height: 14px !important;
+        opacity: 0.85 !important;
+        transform: scale(1);
+        transition: transform 0.25s, opacity 0.25s;
+        box-shadow: ${themeGet('shadows.large')};
+
+        &:active {
+            opacity: 1 !important;
+        }
+    }
+
+    .active .paging-dot {
+        opacity: 1;
+        transform: scale(1.5);
     }
 `;
 
@@ -48,6 +83,7 @@ class About extends Component {
                 <Carousel
                     autoplay={false}
                     cellAlign={'center'}
+                    animation={'zoom'}
                     renderCenterLeftControls={null}
                     renderCenterRightControls={null}
                     renderBottomCenterControls={null}

--- a/src/app/src/components/AboutSlide.js
+++ b/src/app/src/components/AboutSlide.js
@@ -8,7 +8,6 @@ import { themeGet } from 'styled-system';
 import Video from './Video';
 
 const StyledAboutSlide = styled(Flex)`
-    height: 80vh;
     padding: 1rem;
     align-items: center;
 
@@ -83,7 +82,15 @@ export default class AboutSlide extends Component {
     };
 
     render() {
-        const { active, description, job, name, title, videoPath } = this.props;
+        const {
+            active,
+            descriptionIntro,
+            description,
+            job,
+            name,
+            title,
+            videoPath,
+        } = this.props;
         const muteIcon = this.state.muted ? 'volume' : 'volume-slash';
         const muteIconColor = this.state.muted ? '#fff' : '#666';
 
@@ -131,6 +138,7 @@ export default class AboutSlide extends Component {
                             </Heading>
                         </>
                     )}
+                    <Text>{descriptionIntro}</Text>
                     <Text>{description}</Text>
                 </Flex>
             </StyledAboutSlide>

--- a/src/app/src/components/AboutSlide.js
+++ b/src/app/src/components/AboutSlide.js
@@ -39,6 +39,25 @@ const MuteButton = styled(Button)`
     left: 1rem;
 `;
 
+const VideoDescription = styled(Box)`
+    padding-left: 3rem;
+`;
+
+const VideoHeading = styled(Heading)`
+    line-height: ${themeGet('lineHeights.medium')};
+`;
+
+const NameText = styled(Text)`
+    margin-bottom: 0;
+`;
+
+const JobText = styled(Text)`
+    font-style: ${themeGet('fontStyles.italic')};
+    line-height: ${themeGet('lineHeights.medium')};
+    opacity: 0.5;
+    margin-bottom: ${themeGet('space.medium')};
+`;
+
 export default class AboutSlide extends Component {
     constructor(props) {
         super(props);
@@ -114,32 +133,27 @@ export default class AboutSlide extends Component {
                         <FontAwesomeIcon icon={['fa', muteIcon]} />
                     </MuteButton>
                 </VideoContainer>
-                <Box width={2 / 5} pl='3rem'>
-                    <Heading
-                        as='h2'
-                        variant='base'
-                        mb='spacious'
-                        lineHeight='medium'
-                    >
+                <VideoDescription width={2 / 5}>
+                    <VideoHeading as='h2' variant='base'>
                         {title}
-                    </Heading>
+                    </VideoHeading>
                     {job && (
                         <>
                             <Heading as='h3' variant='xSmall'>
                                 Name
                             </Heading>
-                            <Text mb='0'>{name}</Text>
-                            <Text as='em' lineHeight='medium' opacity={0.5}>
-                                {job}
-                            </Text>
-                            <Heading mt='medium' as='h3' variant='xSmall'>
+                            <NameText>{name}</NameText>
+                            <JobText>{job}</JobText>
+                            <Heading as='h3' variant='xSmall'>
                                 What he does
                             </Heading>
                         </>
                     )}
-                    <Text variant='large'>{descriptionIntro}</Text>
+                    {descriptionIntro && (
+                        <Text variant='large'>{descriptionIntro}</Text>
+                    )}
                     <Text>{description}</Text>
-                </Box>
+                </VideoDescription>
             </StyledAboutSlide>
         );
     }

--- a/src/app/src/components/AboutSlide.js
+++ b/src/app/src/components/AboutSlide.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Flex } from 'rebass';
+import { Flex, Box } from 'rebass';
 import { Heading, Text, Button } from './custom-styled-components';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -9,11 +9,11 @@ import Video from './Video';
 
 const StyledAboutSlide = styled(Flex)`
     padding: 1rem;
-    align-items: center;
+    justify-content: flex-start;
 
     video {
         margin: auto;
-        height: fit-content;
+        height: 60vh;
         max-width: 100%;
     }
 `;
@@ -27,16 +27,10 @@ const VideoContainer = styled(Flex)`
 
 const PlayButton = styled(Button)`
     position: absolute;
-    background: gray;
-    height: 300px;
-    width: 300px;
-    border-radius: 50%;
-    opacity: 0.5;
     top: 50%;
-    left: 18%;
-    transform: translateY(-50%);
+    left: 50%;
+    transform: translateX(-50%) translateY(-50%);
     font-size: 150px;
-    text-align: center;
 `;
 
 const MuteButton = styled(Button)`
@@ -105,8 +99,11 @@ export default class AboutSlide extends Component {
                         muted={this.state.muted}
                     />
                     {!this.state.playing && (
-                        <PlayButton onClick={this.togglePlayPause}>
-                            ▶
+                        <PlayButton
+                            variant='link'
+                            onClick={this.togglePlayPause}
+                        >
+                            <FontAwesomeIcon icon={['fas', 'play-circle']} />
                         </PlayButton>
                     )}
                     <MuteButton
@@ -117,13 +114,13 @@ export default class AboutSlide extends Component {
                         <FontAwesomeIcon icon={['fa', muteIcon]} />
                     </MuteButton>
                 </VideoContainer>
-                <Flex
-                    width={2 / 5}
-                    padding='2rem'
-                    margin='auto'
-                    flexDirection='column'
-                >
-                    <Heading as='h2' variant='small'>
+                <Box width={2 / 5} pl='3rem'>
+                    <Heading
+                        as='h2'
+                        variant='base'
+                        mb='spacious'
+                        lineHeight='medium'
+                    >
                         {title}
                     </Heading>
                     {job && (
@@ -131,16 +128,18 @@ export default class AboutSlide extends Component {
                             <Heading as='h3' variant='xSmall'>
                                 Name
                             </Heading>
-                            <Text>{name}</Text>
-                            <Text>{job}</Text>
-                            <Heading as='h3' variant='xSmall'>
+                            <Text mb='0'>{name}</Text>
+                            <Text as='em' lineHeight='medium' opacity={0.5}>
+                                {job}
+                            </Text>
+                            <Heading mt='medium' as='h3' variant='xSmall'>
                                 What he does
                             </Heading>
                         </>
                     )}
-                    <Text>{descriptionIntro}</Text>
+                    <Text variant='large'>{descriptionIntro}</Text>
                     <Text>{description}</Text>
-                </Flex>
+                </Box>
             </StyledAboutSlide>
         );
     }

--- a/src/app/src/components/Heading.js
+++ b/src/app/src/components/Heading.js
@@ -20,19 +20,19 @@ const Heading = styled(BaseHeading)`
         props.variant === 'base' &&
         css`
             font-size: ${themeGet('fontSizes.3')};
-            margin-bottom: ${themeGet('space.compact')};
+            margin-bottom: ${themeGet('space.medium')};
         `};
     ${props =>
         props.variant === 'small' &&
         css`
             font-size: ${themeGet('fontSizes.2')};
-            margin-bottom: ${themeGet('space.small')};
+            margin-bottom: ${themeGet('space.medium')};
         `};
     ${props =>
         props.variant === 'xSmall' &&
         css`
             font-size: ${themeGet('fontSizes.1')};
-            margin-bottom: ${themeGet('space.small')};
+            margin-bottom: ${themeGet('space.tiny')};
             text-transform: uppercase;
             letter-spacing: 1px;
         `};

--- a/src/app/src/components/Screensaver.js
+++ b/src/app/src/components/Screensaver.js
@@ -19,13 +19,14 @@ const Screensaver = props => {
 
     return (
         <StyledScreensaver onClick={() => dispatch(hideScreensaver())}>
-            <Box>
+            <Box width={4 / 5}>
                 <Heading
                     as='h1'
                     variant='medium'
                     textShadow='large'
                     fontWeight='medium'
                     opacity={0.9}
+                    lineHeight='medium'
                 >
                     Learn how fishways help fish reach their spawning grounds
                     and test your fish identification skills!

--- a/src/app/src/components/Text.js
+++ b/src/app/src/components/Text.js
@@ -42,6 +42,7 @@ Text.PropTypes = {
 Text.defaultProps = {
     color: 'white',
     fontWeight: 'normal',
+    fontStyle: 'normal',
     lineHeight: 'normal',
     mb: 'small',
     opacity: '0.8',

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -88,7 +88,7 @@ export const ABOUT_PROFILES = [
         videoPath: overviewVideo,
     },
     {
-        title: 'Meet the Biologist',
+        title: 'How do biologists use  the fishway?',
         name: 'Joe Perillo',
         job: 'Aquatic Biologist, PWD',
         description:
@@ -96,7 +96,7 @@ export const ABOUT_PROFILES = [
         videoPath: biologistVideo,
     },
     {
-        title: 'Meet the Engineer',
+        title: 'How do engineers use  the fishway?',
         name: 'Chad Pindar',
         job: 'Water Resources Engineer, PWD',
         description:
@@ -104,7 +104,7 @@ export const ABOUT_PROFILES = [
         videoPath: engineerVideo,
     },
     {
-        title: 'Dams Along the Schuylkill',
+        title: 'What about other dams along the Schuylkill River?',
         name: 'Glenn McKenzie',
         job: 'Engineer, Army Corps of Engineers',
         description:

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -88,6 +88,7 @@ export const ABOUT_PROFILES = [
         videoPath: overviewVideo,
     },
     {
+        // eslint-disable-next-line no-multi-str
         title: 'How do biologists use  the fishway?',
         name: 'Joe Perillo',
         job: 'Aquatic Biologist, PWD',
@@ -96,6 +97,7 @@ export const ABOUT_PROFILES = [
         videoPath: biologistVideo,
     },
     {
+        // eslint-disable-next-line no-multi-str
         title: 'How do engineers use  the fishway?',
         name: 'Chad Pindar',
         job: 'Water Resources Engineer, PWD',

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -78,11 +78,13 @@ export const GUESS_MESSAGE_TIME = 2500; //in ms
 
 export const ABOUT_PROFILES = [
     {
-        title: 'About the Fishway',
+        title: 'History of the fishway',
         name: '',
         job: '',
+        descriptionIntro:
+            'When the Fairmount Dam was installed, it helped bring water to people, but was detrimental to fish who couldn’t cross to the other side.',
         description:
-            'The Fish Ladder at the Fairmount Dam was constructed in 1979. This animated 3-D video explains how the Fish Ladder works, and how it helps fish to migrate, and survive.',
+            'To counteract the negative environmental effects, the fishway at the Fairmount Dam was constructed in 1979. This animated 3-D video explains how the Fish Ladder works, and how it helps fish to migrate, and survive.',
         videoPath: overviewVideo,
     },
     {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -88,8 +88,7 @@ export const ABOUT_PROFILES = [
         videoPath: overviewVideo,
     },
     {
-        // eslint-disable-next-line no-multi-str
-        title: 'How do biologists use  the fishway?',
+        title: 'How do biologists use the fishway?',
         name: 'Joe Perillo',
         job: 'Aquatic Biologist, PWD',
         description:
@@ -97,8 +96,7 @@ export const ABOUT_PROFILES = [
         videoPath: biologistVideo,
     },
     {
-        // eslint-disable-next-line no-multi-str
-        title: 'How do engineers use  the fishway?',
+        title: 'How do engineers use the fishway?',
         name: 'Chad Pindar',
         job: 'Water Resources Engineer, PWD',
         description:

--- a/src/app/src/util/globalStyle.js
+++ b/src/app/src/util/globalStyle.js
@@ -82,6 +82,14 @@ const GlobalStyle = createGlobalStyle`
     .tab-pane[aria-hidden='true'] {
         display: none;
     }
+
+    em {
+        font-style: italic;
+    }
+
+    strong {
+        font-weight: bold;
+    }
 `;
 
 export default GlobalStyle;

--- a/src/app/src/util/theme.js
+++ b/src/app/src/util/theme.js
@@ -15,6 +15,10 @@ export default {
         '7.594rem', // 6
         '11.391rem', // 7
     ],
+    fontStyles: {
+        normal: 'normal',
+        italic: 'italic',
+    },
     fontWeights: {
         normal: '400',
         medium: '500',
@@ -23,7 +27,8 @@ export default {
     },
     lineHeights: {
         compact: '1',
-        normal: '1.25',
+        medium: '1.25',
+        normal: '1.65',
         comfortable: '1.85',
     },
     letterSpacings: {
@@ -50,6 +55,7 @@ export default {
         black: '#000',
     },
     space: {
+        0: '0',
         tiny: '2px',
         small: '0.5rem',
         compact: '1rem',


### PR DESCRIPTION
## Overview
Styles the About tab so it matches the visual designs. 

Connects #92

### Demo
<img width="1057" alt="Screen Shot 2019-06-05 at 2 33 42 PM" src="https://user-images.githubusercontent.com/5672295/58982253-059ae600-87a2-11e9-8147-2cdf4c062a72.png">
<img width="1057" alt="Screen Shot 2019-06-05 at 2 33 51 PM" src="https://user-images.githubusercontent.com/5672295/58982254-059ae600-87a2-11e9-8fa0-eaf5e48976d2.png">
<img width="1055" alt="Screen Shot 2019-06-05 at 2 34 00 PM" src="https://user-images.githubusercontent.com/5672295/58982255-06337c80-87a2-11e9-9b75-7fda933e6d28.png">
![slider_gif](https://user-images.githubusercontent.com/5672295/58982368-4bf04500-87a2-11e9-8560-501de1532ee5.gif)

### Notes
- The screenshots are set to the proportions of the touchscreen that this app will live on: 1920x1080.
- I had to use `!important` on a few styles for the Nuka Carousel's paging dots. I browsed the Github for the project and this seems to be an (unresolved) issue that others have had.
- The font sizes are generally looking a little small compared to the designs, so I may adjust these later down the road. 
- I also fixed up some styles on the Screensaver—there's now a max-width on the text:
<img width="864" alt="Screen Shot 2019-06-05 at 2 55 20 PM" src="https://user-images.githubusercontent.com/5672295/58982237-fb78e780-87a1-11e9-81a5-65f5d1ffbf92.png">

## Testing Instructions
- `git pull`
- Open "Inspector" and activate "device toolbar". Set to "Responsive" and change the dimensions to 1920x1080.
- Note that Screensaver text doesn't go the full width of the screen anymore (it should be on 2 lines now)
- Click anywhere
- Pause the video on the About pane
- Click on paging dots or click and drag to see other videos.
