### PR TITLE
Implement quiz navbar and handle end of quiz when questions run out

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -48,7 +48,7 @@
     "jest-resolve": "23.6.0",
     "jest-watch-typeahead": "^0.2.1",
     "leaflet": "~1.3.1",
-    "lodash-es": "^4.17.11",
+    "lodash": "^4.17.11",
     "mini-css-extract-plugin": "0.5.0",
     "moment": "^2.24.0",
     "nuka-carousel": "~4.5.4",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -48,6 +48,7 @@
     "jest-resolve": "23.6.0",
     "jest-watch-typeahead": "^0.2.1",
     "leaflet": "~1.3.1",
+    "lodash-es": "^4.17.11",
     "mini-css-extract-plugin": "0.5.0",
     "moment": "^2.24.0",
     "nuka-carousel": "~4.5.4",

--- a/src/app/src/actions.js
+++ b/src/app/src/actions.js
@@ -7,4 +7,6 @@ export const resetTimer = createAction('Reset timer');
 export const pauseTimer = createAction('Pause timer');
 export const showQuiz = createAction('Show quiz');
 export const hideQuiz = createAction('Hide quiz');
+export const saveQuizResults = createAction('Save quiz results');
+export const clearQuizResults = createAction('Clear quiz results');
 export const setBackgroundPosition = createAction('Set Background position');

--- a/src/app/src/components/FishNames.js
+++ b/src/app/src/components/FishNames.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { string } from 'prop-types';
+import { Flex } from 'rebass';
+import styled from 'styled-components';
+import { themeGet } from 'styled-system';
+
+import { Heading, Text } from './custom-styled-components';
+
+const StyledFishNames = styled(Flex)`
+    flex-direction: column;
+`;
+
+const CommonName = styled(Heading)`
+    color: ${themeGet('colors.white')};
+    margin-bottom: 0;
+`;
+
+const ScientificName = styled(Text)`
+    color: ${themeGet('colors.white')};
+    font-style: italic;
+`;
+
+const FishNames = ({ commonName, scientificName }) => {
+    return (
+        <StyledFishNames>
+            <CommonName as='h3' variant='small'>
+                {commonName}
+            </CommonName>
+            <ScientificName variant='small'>{scientificName}</ScientificName>
+        </StyledFishNames>
+    );
+};
+
+FishNames.propTypes = {
+    commonName: string.isRequired,
+    scientificName: string.isRequired,
+};
+
+export default FishNames;

--- a/src/app/src/components/Heading.js
+++ b/src/app/src/components/Heading.js
@@ -8,8 +8,18 @@ const variant = style({
     cssProperty: 'variant',
 });
 
+const fontStyle = style({
+    prop: 'fontStyle',
+    cssProperty: 'font-style',
+});
+
 const Heading = styled(BaseHeading)`
     ${opacity};
+    ${props =>
+        !!props.fontStyle &&
+        css`
+            font-style: ${props.fontStyle};
+        `};
     ${props =>
         props.variant === 'medium' &&
         css`
@@ -42,11 +52,13 @@ Heading.displayName = 'Heading';
 
 Heading.propTypes = {
     variant: PropTypes.string.isRequired,
+    fontStyle: PropTypes.string.isRequired,
 };
 
 Heading.PropTypes = {
     ...variant.PropTypes,
     ...opacity.PropTypes,
+    ...fontStyle.PropTypes,
 };
 
 Heading.defaultProps = {
@@ -55,6 +67,7 @@ Heading.defaultProps = {
     fontWeight: 'semibold',
     opacity: '1',
     variant: 'base',
+    fontStyle: 'none',
 };
 
 export default Heading;

--- a/src/app/src/components/MeetTheFish.js
+++ b/src/app/src/components/MeetTheFish.js
@@ -39,7 +39,7 @@ const FishButtonAndModal = styled(Box)`
 
 const FishReel = styled(Flex)`
     flex-wrap: wrap;
-    width: 400%;
+    width: 280%;
 `;
 
 const MeetTheFish = () => {

--- a/src/app/src/components/MeetTheFishButton.js
+++ b/src/app/src/components/MeetTheFishButton.js
@@ -7,8 +7,8 @@ import { CatalogFish } from '../util/CatalogFish';
 import { FISH_MODAL_OPEN_DELAY } from '../util/constants';
 
 const FishImage = styled.img`
-    max-width: 400px;
-    max-height: 450px;
+    max-width: 350px;
+    max-height: 400px;
     transition: transform 1s linear;
 
     &.large {

--- a/src/app/src/components/MeetTheFishButton.js
+++ b/src/app/src/components/MeetTheFishButton.js
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { func, number, bool } from 'prop-types';
 
-import { Heading, Text } from './custom-styled-components';
 import { CatalogFish } from '../util/CatalogFish';
 import { FISH_MODAL_OPEN_DELAY } from '../util/constants';
+
+import FishNames from './FishNames';
 
 const FishImage = styled.img`
     max-width: 350px;
@@ -28,13 +29,6 @@ const FishButton = styled.button`
 const MeetTheFishButton = ({ fish, index, disabled, onButtonClick }) => {
     const [isFishLarge, setIsFishLarge] = useState(false);
 
-    const caption = (
-        <Heading as='h2' variant='small'>
-            {fish.commonName}
-            <Text variant='small'>{fish.scientificName}</Text>
-        </Heading>
-    );
-
     const onFishClicked = () => {
         setIsFishLarge(true);
         setTimeout(() => setIsFishLarge(false), FISH_MODAL_OPEN_DELAY);
@@ -55,7 +49,10 @@ const MeetTheFishButton = ({ fish, index, disabled, onButtonClick }) => {
                     className={isFishLarge && 'large'}
                     alt={fish.commonName}
                 />
-                {caption}
+                <FishNames
+                    commonName={fish.commonName}
+                    scientificName={fish.scientificName}
+                />
             </FishButton>
         </>
     );

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -1,4 +1,4 @@
-import shuffle from 'lodash-es/shuffle';
+import shuffle from 'lodash/shuffle';
 import React from 'react';
 import styled from 'styled-components';
 import { Box, Flex } from 'rebass';

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -10,7 +10,7 @@ import QuizQuestion from './QuizQuestion';
 import QuizSidebar from './QuizSidebar';
 
 import { QUIZ_FISH, GUESS_MESSAGE_TIME } from '../util/constants';
-import { hideQuiz } from '../actions';
+import { hideQuiz, saveQuizResults } from '../actions';
 
 const QuizContainer = styled(Flex)`
     text-align: center;
@@ -50,6 +50,7 @@ class Quiz extends React.Component {
         setTimeout(() => {
             const { dispatch } = this.props;
             if (this.state.question === 1) {
+                dispatch(saveQuizResults(this.state.results));
                 dispatch(hideQuiz());
             } else
                 this.setState({

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -9,7 +9,11 @@ import QuizGuess from './QuizGuess';
 import QuizQuestion from './QuizQuestion';
 import QuizSidebar from './QuizSidebar';
 
-import { QUIZ_FISH, GUESS_MESSAGE_TIME } from '../util/constants';
+import {
+    QUIZ_FISH,
+    GUESS_MESSAGE_TIME,
+    NUM_QUIZ_QUESTIONS,
+} from '../util/constants';
 import { hideQuiz, saveQuizResults } from '../actions';
 
 const QuizContainer = styled(Flex)`
@@ -24,7 +28,7 @@ const QuizBody = styled(Box)`
 class Quiz extends React.Component {
     constructor() {
         super();
-        const answers = shuffle(QUIZ_FISH).slice(0, 2);
+        const answers = shuffle(QUIZ_FISH).slice(0, NUM_QUIZ_QUESTIONS);
         const choices = answers.map(fish => {
             const otherFish = QUIZ_FISH.filter(
                 a => a.commonName !== fish.commonName
@@ -49,7 +53,7 @@ class Quiz extends React.Component {
 
         setTimeout(() => {
             const { dispatch } = this.props;
-            if (this.state.question === 1) {
+            if (this.state.question === NUM_QUIZ_QUESTIONS - 1) {
                 dispatch(saveQuizResults(this.state.results));
                 dispatch(hideQuiz());
             } else

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -10,6 +10,7 @@ import QuizQuestion from './QuizQuestion';
 import QuizSidebar from './QuizSidebar';
 
 import { QUIZ_FISH, GUESS_MESSAGE_TIME } from '../util/constants';
+import { hideQuiz } from '../actions';
 
 const QuizContainer = styled(Flex)`
     text-align: center;
@@ -23,7 +24,7 @@ const QuizBody = styled(Box)`
 class Quiz extends React.Component {
     constructor() {
         super();
-        const answers = shuffle(QUIZ_FISH).slice(0, 5);
+        const answers = shuffle(QUIZ_FISH).slice(0, 2);
         const choices = answers.map(fish => {
             const otherFish = QUIZ_FISH.filter(
                 a => a.commonName !== fish.commonName
@@ -45,14 +46,17 @@ class Quiz extends React.Component {
             currentResult: result,
             results: this.state.results.concat(result),
         });
-        setTimeout(
-            () =>
+
+        setTimeout(() => {
+            const { dispatch } = this.props;
+            if (this.state.question === 1) {
+                dispatch(hideQuiz());
+            } else
                 this.setState({
                     currentResult: null,
                     question: this.state.question + 1,
-                }),
-            GUESS_MESSAGE_TIME
-        );
+                });
+        }, GUESS_MESSAGE_TIME);
     };
 
     render() {
@@ -63,6 +67,7 @@ class Quiz extends React.Component {
             question,
             answers,
         } = this.state;
+
         const answer = answers[question];
 
         const correctGuess =

--- a/src/app/src/components/QuizGuess.js
+++ b/src/app/src/components/QuizGuess.js
@@ -2,8 +2,10 @@ import { bool } from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import { Flex } from 'rebass';
+import { themeGet } from 'styled-system';
 
 import Text from './Text';
+import Heading from './Heading';
 
 import { QuizFish } from '../util/QuizFish';
 
@@ -12,25 +14,85 @@ const StyledQuizGuess = styled(Flex)`
     flex-direction: column;
 `;
 
-const Answer = styled(Flex)`
-    flex-direction: column;
+const Answer = styled.div`
     text-align: center;
 `;
 
+const Circle = styled.div`
+    width: 400px;
+    height: 400px;
+    max-width: 60%;
+    position: absolute;
+    top: 60%;
+    left: 50%;
+    background-color: ${themeGet('colors.teals.2')};
+    transform: translate(-50%, -50%);
+    border-radius: 400px;
+    z-index: 1;
+`;
+
+const Message = styled(Heading)`
+    position: absolute;
+    top: 35%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 2;
+`;
+
+const CorrectMessage = styled(Message)`
+    color: ${themeGet('colors.greens.3')};
+    font-weight: 900;
+    font-size: 8.5rem;
+    top: 40%;
+`;
+
+const FishImage = styled.img`
+    width: auto;
+    height: auto;
+    max-width: 60%;
+    max-height: 55%;
+    position: absolute;
+    top: 60%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 3;
+`;
+
+const CaptionText = styled(Flex)`
+    flex-direction: column;
+    position: absolute;
+    top: 85%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 3;
+`;
+
 const QuizGuess = ({ answer, correct }) => {
-    const message = correct ? 'CORRECT!' : 'Sorry, it was the:';
+    const correctText = <CorrectMessage>Correct!</CorrectMessage>;
+    const incorrectText = (
+        <Message variant='small' fontStyle='italic' opacity={0.7}>
+            Sorry, it was the:
+        </Message>
+    );
+    const message = correct ? correctText : incorrectText;
 
     return (
         <StyledQuizGuess>
+            {message}
             <Answer>
-                {message}
-                <img src={answer.picturePath} alt='Illustration of the fish' />
-                <Text as='h2' variant='base'>
-                    {answer.commonName}
-                </Text>
-                <Text as='h3' variant='xSmall'>
-                    {answer.scientificName}
-                </Text>
+                <Circle />
+                <FishImage
+                    src={answer.picturePath}
+                    alt='Illustration of the fish'
+                />
+                <CaptionText>
+                    <Text as='h2' variant='base'>
+                        {answer.commonName}
+                    </Text>
+                    <Text as='h3' variant='xSmall' fontStyle='italic'>
+                        {answer.scientificName}
+                    </Text>
+                </CaptionText>
             </Answer>
             <Text as='h2' variant='xSmall'>
                 {answer.hint}

--- a/src/app/src/components/QuizGuess.js
+++ b/src/app/src/components/QuizGuess.js
@@ -8,6 +8,7 @@ import Text from './Text';
 import Heading from './Heading';
 
 import { QuizFish } from '../util/QuizFish';
+import FishNames from './FishNames';
 
 const StyledQuizGuess = styled(Flex)`
     text-align: center;
@@ -49,8 +50,8 @@ const CorrectMessage = styled(Message)`
 const FishImage = styled.img`
     width: auto;
     height: auto;
-    max-width: 60%;
-    max-height: 55%;
+    max-width: 50%;
+    max-height: 45%;
     position: absolute;
     top: 60%;
     left: 50%;
@@ -86,12 +87,10 @@ const QuizGuess = ({ answer, correct }) => {
                     alt='Illustration of the fish'
                 />
                 <CaptionText>
-                    <Text as='h2' variant='base'>
-                        {answer.commonName}
-                    </Text>
-                    <Text as='h3' variant='xSmall' fontStyle='italic'>
-                        {answer.scientificName}
-                    </Text>
+                    <FishNames
+                        commonName={answer.commonName}
+                        scientificName={answer.scientificName}
+                    />
                 </CaptionText>
             </Answer>
             <Text as='h2' variant='xSmall'>

--- a/src/app/src/components/QuizHome.js
+++ b/src/app/src/components/QuizHome.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { func } from 'prop-types';
 import { Flex, Box } from 'rebass';
 import { Heading, Text, Button } from './custom-styled-components';
 import styled from 'styled-components';
-import { showQuiz } from '../actions';
+import { showQuiz, clearQuizResults } from '../actions';
 
 const StyledQuizHome = styled(Flex)`
     text-align: center;
@@ -13,29 +13,42 @@ const StyledQuizHome = styled(Flex)`
     justify-content: center;
 `;
 
-const QuizHome = props => {
-    const { dispatch } = props;
-    return (
-        <StyledQuizHome>
-            <Box width={1 / 2} mb='4'>
-                <Heading as='h1'>Test your skills</Heading>
-                <Text as='p' variant='large'>
-                    Aquatic biologists need to identify each fish that moves
-                    through the fishway. This can be tough, because fish swim
-                    fast and are hard to see!
-                </Text>
-                <Text as='p'>
-                    Watch the clip of fish moving through the fishway and match
-                    it to the correct fish. Work quickly and carefully to get
-                    the highest score!
-                </Text>
-            </Box>
-            <Button mt='compact' onClick={() => dispatch(showQuiz())}>
-                Play
+class QuizHome extends Component {
+    componentWillUnmount() {
+        const { dispatch } = this.props;
+        dispatch(clearQuizResults());
+    }
+
+    render() {
+        const { dispatch, finalQuizState } = this.props;
+
+        const quizHomeState = finalQuizState ? (
+            <Button mt='compact' onClick={() => dispatch(clearQuizResults())}>
+                Try again
             </Button>
-        </StyledQuizHome>
-    );
-};
+        ) : (
+            <>
+                <Box width={1 / 2} mb='4'>
+                    <Heading as='h1'>Test your skills</Heading>
+                    <Text as='p' variant='large'>
+                        Aquatic biologists need to identify each fish that moves
+                        through the fishway. This can be tough, because fish
+                        swim fast and are hard to see!
+                    </Text>
+                    <Text as='p'>
+                        Watch the clip of fish moving through the fishway and
+                        match it to the correct fish. Work quickly and carefully
+                        to get the highest score!
+                    </Text>
+                </Box>
+                <Button mt='compact' onClick={() => dispatch(showQuiz())}>
+                    Play
+                </Button>
+            </>
+        );
+        return <StyledQuizHome>{quizHomeState}</StyledQuizHome>;
+    }
+}
 
 QuizHome.propTypes = {
     dispatch: func.isRequired,
@@ -44,6 +57,7 @@ QuizHome.propTypes = {
 function mapStateToProps(state) {
     return {
         dispatch: state.dispatch,
+        finalQuizState: state.finalQuizState,
     };
 }
 export default connect(mapStateToProps)(QuizHome);

--- a/src/app/src/components/QuizNavbar.js
+++ b/src/app/src/components/QuizNavbar.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { func } from 'prop-types';
+import { arrayOf, func, number } from 'prop-types';
 import styled from 'styled-components';
-import { Flex } from 'rebass';
+import { Box, Flex } from 'rebass';
 import { Heading, Button } from './custom-styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { hideQuiz } from '../actions';
+import { QuizResult } from '../util/QuizResult';
 
 const StyledQuizNavbar = styled(Flex)`
     display: flex;
@@ -17,13 +18,28 @@ const StyledQuizNavbar = styled(Flex)`
     padding: 0 10px 0 30px;
 `;
 
+const Result = styled(Box)`
+    flex: none;
+    border-bottom: ${props => (props.current ? '1px solid green' : null)};
+`;
+
 const QuizNavbar = props => {
-    const { dispatch } = props;
+    const { dispatch, question, results } = props;
+    const icons = [0, 1, 2, 3, 4].map(idx => {
+        const result = results[idx];
+        const correct = result && result.numWrong < 2;
+        return (
+            <Result key={idx} current={question === idx} correct={correct}>
+                <FontAwesomeIcon icon={['fas', 'fish']} />
+            </Result>
+        );
+    });
     return (
         <StyledQuizNavbar>
             <Heading as='h1' variant='xSmall' fontSize='0'>
                 TEST YOUR SKILLS
             </Heading>
+            <Flex>{icons}</Flex>
             <Button variant='close' onClick={() => dispatch(hideQuiz())}>
                 <FontAwesomeIcon icon={['fal', 'times']} />
             </Button>
@@ -33,6 +49,8 @@ const QuizNavbar = props => {
 
 QuizNavbar.propTypes = {
     dispatch: func.isRequired,
+    question: number.isRequired,
+    results: arrayOf(QuizResult).isRequired,
 };
 
 export default QuizNavbar;

--- a/src/app/src/components/QuizNavbar.js
+++ b/src/app/src/components/QuizNavbar.js
@@ -25,6 +25,7 @@ const Result = styled(Box)`
 
 const QuizNavbar = props => {
     const { dispatch, question, results } = props;
+
     const icons = [0, 1, 2, 3, 4].map(idx => {
         const result = results[idx];
         const correct = result && result.numWrong < 2;

--- a/src/app/src/components/QuizOption.js
+++ b/src/app/src/components/QuizOption.js
@@ -2,11 +2,9 @@ import { bool } from 'prop-types';
 import React from 'react';
 import { Flex } from 'rebass';
 import styled from 'styled-components';
-import { themeGet } from 'styled-system';
-
-import { Heading, Text } from './custom-styled-components';
 
 import { QuizFish } from '../util/QuizFish';
+import FishNames from './FishNames';
 
 const StyledQuizOption = styled(Flex)`
     flex-direction: column;
@@ -24,15 +22,6 @@ const StyledQuizOption = styled(Flex)`
     }
 `;
 
-const CommonName = styled(Heading)`
-    color: ${themeGet('colors.white')};
-`;
-
-const ScientificName = styled(Text)`
-    color: ${themeGet('colors.white')};
-    font-style: italic;
-`;
-
 const QuizOption = ({ fish, showImage, shadeImage, ...props }) => {
     return (
         <StyledQuizOption
@@ -41,8 +30,10 @@ const QuizOption = ({ fish, showImage, shadeImage, ...props }) => {
             {...props}
         >
             <img src={fish.picturePath} alt='Illustration of the fish' />
-            <CommonName as='h3'>{fish.commonName}</CommonName>
-            <ScientificName>{fish.scientificName}</ScientificName>
+            <FishNames
+                commonName={fish.commonName}
+                scientificName={fish.scientificName}
+            />
         </StyledQuizOption>
     );
 };

--- a/src/app/src/components/QuizQuestion.js
+++ b/src/app/src/components/QuizQuestion.js
@@ -58,7 +58,9 @@ class QuizQuestion extends React.Component {
 
         const showHint = guessed.length > 0 || usedHint;
         // TODO: Remove the default value here when we get hint text
-        let hint = showHint ? answer.hint || 'its number 1' : 'Get a hint';
+        let hint = showHint
+            ? answer.hint || `its ${answer.commonName}`
+            : 'Get a hint';
         if (guessed.length > 0) {
             hint = 'Almost! ' + hint;
         }

--- a/src/app/src/components/QuizQuestion.js
+++ b/src/app/src/components/QuizQuestion.js
@@ -22,8 +22,8 @@ const Options = styled(Flex)`
 `;
 
 const StyledQuizOption = styled(QuizOption)`
-    width: 50%;
-    height: 50%;
+    width: 45%;
+    height: 45%;
     margin: auto;
 `;
 

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Box } from 'rebass';
-import { Heading, Text } from './custom-styled-components';
+import { Text } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 import moment from 'moment';
 
 import { HighlightFish } from '../util/HighlightFish';
 
 import VideoPlayer from './VideoPlayer';
+import FishNames from './FishNames';
 
 const StyledSidebar = styled(Box)`
     background: ${themeGet('colors.teals.5')};
@@ -23,10 +24,10 @@ const Sidebar = ({ fish }) => {
     const videoPlayer = fish && <VideoPlayer src={video} />;
     return (
         <StyledSidebar>
-            <Heading as='h2' variant='small'>
-                {commonName}
-                <Text variant='small'>{scientificName}</Text>
-            </Heading>
+            <FishNames
+                commonName={commonName}
+                scientificName={scientificName}
+            />
             {videoPlayer}
             <footer>
                 <Text variant='small'>{notes}</Text>

--- a/src/app/src/components/Text.js
+++ b/src/app/src/components/Text.js
@@ -59,7 +59,6 @@ Text.defaultProps = {
     mb: 'small',
     opacity: '0.8',
     variant: 'base',
-    fontStyle: 'none',
 };
 
 export default Text;

--- a/src/app/src/components/Text.js
+++ b/src/app/src/components/Text.js
@@ -8,8 +8,18 @@ const variant = style({
     cssProperty: 'variant',
 });
 
+const fontStyle = style({
+    prop: 'fontStyle',
+    cssProperty: 'font-style',
+});
+
 const Text = styled(BaseText)`
     ${opacity};
+    ${props =>
+        !!props.fontStyle &&
+        css`
+            font-style: ${props.fontStyle};
+        `};
     ${props =>
         props.variant === 'large' &&
         css`
@@ -32,11 +42,13 @@ Text.displayName = 'Text';
 
 Text.propTypes = {
     variant: PropTypes.string.isRequired,
+    fontStyle: PropTypes.string.isRequired,
 };
 
 Text.PropTypes = {
     ...variant.PropTypes,
     ...opacity.PropTypes,
+    ...fontStyle.PropTypes,
 };
 
 Text.defaultProps = {
@@ -47,6 +59,7 @@ Text.defaultProps = {
     mb: 'small',
     opacity: '0.8',
     variant: 'base',
+    fontStyle: 'none',
 };
 
 export default Text;

--- a/src/app/src/reducers.js
+++ b/src/app/src/reducers.js
@@ -9,6 +9,8 @@ import {
     pauseTimer,
     showQuiz,
     hideQuiz,
+    saveQuizResults,
+    clearQuizResults,
     setBackgroundPosition,
 } from './actions';
 import { RESET, PAUSE } from './util/constants';
@@ -19,6 +21,7 @@ export const initialState = {
     timerEvent: '',
     isQuizVisible: false,
     backgroundPosition: 'top',
+    finalQuizState: null,
 };
 
 export default createReducer(
@@ -35,6 +38,10 @@ export default createReducer(
         [pauseTimer]: state => update(state, { timerEvent: { $set: PAUSE } }),
         [showQuiz]: state => update(state, { isQuizVisible: { $set: true } }),
         [hideQuiz]: state => update(state, { isQuizVisible: { $set: false } }),
+        [saveQuizResults]: (state, payload) =>
+            update(state, { finalQuizState: { $set: payload } }),
+        [clearQuizResults]: state =>
+            update(state, { finalQuizState: { $set: null } }),
         [setBackgroundPosition]: (state, payload) =>
             update(state, { backgroundPosition: { $set: payload } }),
     },

--- a/src/app/src/util/QuizResult.js
+++ b/src/app/src/util/QuizResult.js
@@ -1,0 +1,6 @@
+import { bool, oneOf, shape } from 'prop-types';
+
+export const QuizResult = shape({
+    numWrong: oneOf([0, 1, 2]).isRequired,
+    usedHint: bool.isRequired,
+});

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -76,6 +76,7 @@ export const RESET = 'RESET';
 export const MAX_IDLE_TIME = 180000; //in ms, should be 180000 (3 minutes)
 export const GUESS_MESSAGE_TIME = 2500; //in ms, should be 2500
 export const FISH_MODAL_OPEN_DELAY = 1000; //in ms, should be 1000
+export const NUM_QUIZ_QUESTIONS = 5;
 
 export const ABOUT_PROFILES = [
     {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -658,7 +658,7 @@ export const QUIZ_FISH = [
         hint: '',
     },
     {
-        HYBRID_STRIPED_BASS,
+        ...HYBRID_STRIPED_BASS,
         videoPath: stripedBassHybridClip,
         hint: '',
     },

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -6798,7 +6798,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.0.0, lodash-es@^4.17.11, lodash-es@^4.17.5, lodash-es@^4.2.1:
+lodash-es@^4.0.0, lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -6798,7 +6798,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.0.0, lodash-es@^4.17.5, lodash-es@^4.2.1:
+lodash-es@^4.0.0, lodash-es@^4.17.11, lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==


### PR DESCRIPTION
## Overview

This PR implements the navbar that shows the user their progress throughout the quiz. It also implements the quiz successfully saving quiz result information and closing the quiz when the questions are finished. Score to be further worked on in #72 

Connects #44 

### Demo

<img width="1417" alt="Screen Shot 2019-06-06 at 4 54 46 PM" src="https://user-images.githubusercontent.com/10568752/59065924-db1d5b80-887b-11e9-846a-ae9f7ad61682.png">
<img width="879" alt="Screen Shot 2019-06-06 at 4 55 02 PM" src="https://user-images.githubusercontent.com/10568752/59065925-db1d5b80-887b-11e9-814e-4f6159bcca66.png">

It is a little tough to see, but will be changed in the future of course, a green underline in the navbar denoting which question you're on.

### Notes

Follow up card to flesh out the fish icons in the quiz navbar, pending budget renewal in July.

I included some other clean up around the app, like refactoring fish names, cleaning up the guess page, and fitting Meet the Fish to the official screen resolution of 1920x1080px !

## Testing Instructions

Play the quiz! :) See that there's no console errors, screen sizing fits a resolution of 1920x1080, and the navbar tracks the quiz question. For now the would-be score page is just a "try again" button. Upon navigating away from the quiz tab, and back, the quiz should be reset.
