### PR TITLE
Display and save quiz duration

### DIFF
--- a/src/app/src/actions.js
+++ b/src/app/src/actions.js
@@ -9,4 +9,7 @@ export const showQuiz = createAction('Show quiz');
 export const hideQuiz = createAction('Hide quiz');
 export const saveQuizResults = createAction('Save quiz results');
 export const clearQuizResults = createAction('Clear quiz results');
+export const saveSecondsToCompleteQuiz = createAction(
+    'Save seconds elapsed to complete the quiz'
+);
 export const setBackgroundPosition = createAction('Set Background position');

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -101,7 +101,7 @@ class Quiz extends React.Component {
                     question={question}
                     results={results}
                 />
-                <Timer />
+                <Timer dispatch={this.props.dispatch} />
                 {quizState}
             </Box>
         );

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -8,6 +8,7 @@ import QuizNavbar from './QuizNavbar';
 import QuizGuess from './QuizGuess';
 import QuizQuestion from './QuizQuestion';
 import QuizSidebar from './QuizSidebar';
+import Timer from './Timer';
 
 import {
     QUIZ_FISH,
@@ -100,6 +101,7 @@ class Quiz extends React.Component {
                     question={question}
                     results={results}
                 />
+                <Timer />
                 {quizState}
             </Box>
         );

--- a/src/app/src/components/QuizHome.js
+++ b/src/app/src/components/QuizHome.js
@@ -58,6 +58,7 @@ function mapStateToProps(state) {
     return {
         dispatch: state.dispatch,
         finalQuizState: state.finalQuizState,
+        secondsToCompleteQuiz: state.secondsToCompleteQuiz,
     };
 }
 export default connect(mapStateToProps)(QuizHome);

--- a/src/app/src/components/Timer.js
+++ b/src/app/src/components/Timer.js
@@ -3,14 +3,22 @@ import styled from 'styled-components';
 import { Box } from 'rebass';
 import { themeGet } from 'styled-system';
 
+import Text from './Text';
+import { saveSecondsToCompleteQuiz } from '../actions';
+
 const StyledTimer = styled(Box)`
-    background: ${themeGet('colors.teals.4')};
     position: absolute;
-    color: white;
+    background-image: linear-gradient(
+        to right,
+        ${themeGet('colors.teals.0')} 30%,
+        ${themeGet('colors.teals.1')} 70%,
+        ${themeGet('colors.teals.2')} 100%
+    );
+    opacity: 11%;
     right: 0px;
     text-align: center;
-    width: 200px;
-    height: 30px;
+    width: 300px;
+    height: 50px;
 `;
 
 class Timer extends Component {
@@ -32,6 +40,10 @@ class Timer extends Component {
     }
 
     componentWillUnmount() {
+        const { dispatch } = this.props;
+        const { elapsedSeconds } = this.state;
+
+        dispatch(saveSecondsToCompleteQuiz(elapsedSeconds));
         clearInterval(this.interval);
     }
 
@@ -45,7 +57,9 @@ class Timer extends Component {
 
         return (
             <StyledTimer>
-                {formattedMins}:{formattedSecs} min
+                <Text variant='large'>
+                    {formattedMins}:{formattedSecs} min
+                </Text>
             </StyledTimer>
         );
     }

--- a/src/app/src/components/Timer.js
+++ b/src/app/src/components/Timer.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+import { Box } from 'rebass';
+import { themeGet } from 'styled-system';
+
+const StyledTimer = styled(Box)`
+    background: ${themeGet('colors.teals.4')};
+    position: absolute;
+    color: white;
+    right: 0px;
+    text-align: center;
+    width: 200px;
+    height: 30px;
+`;
+
+class Timer extends Component {
+    constructor() {
+        super();
+        this.state = {
+            elapsedSeconds: 0,
+        };
+    }
+
+    componentDidMount() {
+        this.interval = setInterval(
+            () =>
+                this.setState(state => ({
+                    elapsedSeconds: state.elapsedSeconds + 1,
+                })),
+            1000
+        );
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.interval);
+    }
+
+    render() {
+        const { elapsedSeconds } = this.state;
+        const minutes = Math.floor(elapsedSeconds / 60);
+        const seconds = elapsedSeconds % 60;
+
+        const formattedMins = ('0' + minutes).slice(-2);
+        const formattedSecs = ('0' + seconds).slice(-2);
+
+        return (
+            <StyledTimer>
+                {formattedMins}:{formattedSecs} min
+            </StyledTimer>
+        );
+    }
+}
+
+export default Timer;

--- a/src/app/src/reducers.js
+++ b/src/app/src/reducers.js
@@ -11,6 +11,7 @@ import {
     hideQuiz,
     saveQuizResults,
     clearQuizResults,
+    saveSecondsToCompleteQuiz,
     setBackgroundPosition,
 } from './actions';
 import { RESET, PAUSE } from './util/constants';
@@ -22,6 +23,7 @@ export const initialState = {
     isQuizVisible: false,
     backgroundPosition: 'top',
     finalQuizState: null,
+    secondsToCompleteQuiz: 0,
 };
 
 export default createReducer(
@@ -42,6 +44,8 @@ export default createReducer(
             update(state, { finalQuizState: { $set: payload } }),
         [clearQuizResults]: state =>
             update(state, { finalQuizState: { $set: null } }),
+        [saveSecondsToCompleteQuiz]: (state, payload) =>
+            update(state, { secondsToCompleteQuiz: { $set: payload } }),
         [setBackgroundPosition]: (state, payload) =>
             update(state, { backgroundPosition: { $set: payload } }),
     },


### PR DESCRIPTION
## Overview

The quiz will be timed and the time will be used to calculate score bonus points. This PR sets up the timer, with lightly attempted styling, and saves it to redux to be used in #72 

Connects #60 

### Demo
<img width="188" alt="Screen Shot 2019-07-01 at 1 38 56 PM" src="https://user-images.githubusercontent.com/10568752/60456908-a9907980-9c08-11e9-940f-78096436b938.png">
<img width="233" alt="Screen Shot 2019-07-01 at 1 39 01 PM" src="https://user-images.githubusercontent.com/10568752/60456909-a9907980-9c08-11e9-842e-c961173d7b9c.png">

Just so you can see the minutes properly formatted:
![Screen Shot 2019-07-01 at 12 42 13 PM](https://user-images.githubusercontent.com/10568752/60457591-68996480-9c0a-11e9-9d2e-1da8b5c2159e.png)


## Testing Instructions

`vagrant up`
`./scripts/server`
http://localhost:3474/
Play the quiz and see the timer~
