### PR TITLE
Hide close button in quiz on in/correct window

### DIFF
--- a/src/app/src/components/Button.js
+++ b/src/app/src/components/Button.js
@@ -9,6 +9,8 @@ import {
     fontFamily,
 } from 'styled-system';
 
+export const buttonWidth = '4rem';
+
 const variant = style({
     prop: 'variant',
     cssProperty: 'variant',
@@ -103,7 +105,7 @@ const Button = styled(BaseButton)`
             font-weight: ${themeGet('fontWeights.semibold')};
             border-radius: 100%;
             padding: 0;
-            width: 4rem;
+            width: ${buttonWidth};
             height: 4rem;
             &:active {
                 opacity: 0.8;

--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -100,6 +100,7 @@ class Quiz extends React.Component {
                     dispatch={this.props.dispatch}
                     question={question}
                     results={results}
+                    isQuestionActive={currentResult === null}
                 />
                 <Timer dispatch={this.props.dispatch} />
                 {quizState}

--- a/src/app/src/components/QuizNavbar.js
+++ b/src/app/src/components/QuizNavbar.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { arrayOf, func, number } from 'prop-types';
+import { arrayOf, func, number, bool } from 'prop-types';
 import styled from 'styled-components';
 import { Box, Flex } from 'rebass';
-import { Heading, Button } from './custom-styled-components';
+import { Heading, Button, buttonWidth } from './custom-styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { hideQuiz } from '../actions';
@@ -23,8 +23,12 @@ const Result = styled(Box)`
     border-bottom: ${props => (props.current ? '1px solid green' : null)};
 `;
 
+const CloseButtonPlaceholder = styled(Box)`
+    width: ${buttonWidth};
+`;
+
 const QuizNavbar = props => {
-    const { dispatch, question, results } = props;
+    const { dispatch, question, results, isQuestionActive } = props;
 
     const icons = [0, 1, 2, 3, 4].map(idx => {
         const result = results[idx];
@@ -35,15 +39,24 @@ const QuizNavbar = props => {
             </Result>
         );
     });
+
+    // Without a close button, still render a placeholder element
+    // to maintain quiz navbar spacing
+    const closeButton = isQuestionActive ? (
+        <Button variant='close' onClick={() => dispatch(hideQuiz())}>
+            <FontAwesomeIcon icon={['fal', 'times']} />
+        </Button>
+    ) : (
+        <CloseButtonPlaceholder />
+    );
+
     return (
         <StyledQuizNavbar>
             <Heading as='h1' variant='xSmall' fontSize='0'>
                 TEST YOUR SKILLS
             </Heading>
             <Flex>{icons}</Flex>
-            <Button variant='close' onClick={() => dispatch(hideQuiz())}>
-                <FontAwesomeIcon icon={['fal', 'times']} />
-            </Button>
+            {closeButton}
         </StyledQuizNavbar>
     );
 };
@@ -52,6 +65,7 @@ QuizNavbar.propTypes = {
     dispatch: func.isRequired,
     question: number.isRequired,
     results: arrayOf(QuizResult).isRequired,
+    isQuestionActive: bool.isRequired,
 };
 
 export default QuizNavbar;

--- a/src/app/src/components/custom-styled-components.js
+++ b/src/app/src/components/custom-styled-components.js
@@ -1,3 +1,3 @@
-export { default as Button } from './Button';
+export { default as Button, buttonWidth } from './Button';
 export { default as Heading } from './Heading';
 export { default as Text } from './Text';


### PR DESCRIPTION
## Overview

This PR conditionally shows/hides the close button in the quiz navbar. The close button quits the quiz, specifically, but it can be misinterpreted. Specifically it can be misread as an exit button to the flashing message between quiz questions, but would exit the quiz.  Prevent a user from accidentally exiting the quiz during this transient message.

Connects #68

### Demo
The navbar looking the same during the transient message and during the quiz

<img width="1438" alt="Screen Shot 2019-07-02 at 11 55 56 AM" src="https://user-images.githubusercontent.com/10568752/60528113-bb822300-9cc1-11e9-9189-16a41e61d3f6.png">
<img width="1438" alt="Screen Shot 2019-07-02 at 11 55 59 AM" src="https://user-images.githubusercontent.com/10568752/60528114-bb822300-9cc1-11e9-8394-a4f64262c295.png">

## Testing Instructions

Play the quiz in the Netlify site and see the close button is not present in the in/correct view
