### PR TITLE
Style See the Fishway tab

### DIFF
--- a/src/app/src/components/Background.js
+++ b/src/app/src/components/Background.js
@@ -18,7 +18,7 @@ const StyledBackground = styled(Box)`
     );
     background-size: 100% 500%;
     background-position: top;
-    position: absolute;
+    position: fixed;
     top: 10%;
     right: 0;
     bottom: 0;

--- a/src/app/src/components/FishNames.js
+++ b/src/app/src/components/FishNames.js
@@ -11,22 +11,23 @@ const StyledFishNames = styled(Flex)`
 `;
 
 const CommonName = styled(Heading)`
-    color: ${themeGet('colors.white')};
     margin-bottom: 0;
+    line-height: ${themeGet('lineHeights.compact')};
+    font-size: 2rem;
 `;
 
 const ScientificName = styled(Text)`
-    color: ${themeGet('colors.white')};
     font-style: italic;
+    margin-bottom: ${themeGet('space.medium')};
 `;
 
 const FishNames = ({ commonName, scientificName }) => {
     return (
         <StyledFishNames>
-            <CommonName as='h3' variant='small'>
-                {commonName}
-            </CommonName>
-            <ScientificName variant='small'>{scientificName}</ScientificName>
+            <CommonName as='h3'>{commonName}</CommonName>
+            <ScientificName as='h4' variant='base'>
+                {scientificName}
+            </ScientificName>
         </StyledFishNames>
     );
 };

--- a/src/app/src/components/Navbar.js
+++ b/src/app/src/components/Navbar.js
@@ -14,11 +14,14 @@ import QuizHome from './QuizHome';
 import { ABOUT, SEE, MEET, TEST, POSITIONS } from '../util/constants';
 
 const StyledTabs = styled(Tabs)`
+    position: sticky;
+    top: 0;
+    z-index: 1;
     width: 100%;
     display: flex;
     justify-content: space-evenly;
     align-items: center;
-    height: 5rem;
+    height: ${themeGet('navHeight')};
     border-bottom: 1px solid rgba(256, 256, 256, 0.2);
 
     .nav-item {

--- a/src/app/src/components/SeeTheFishway.js
+++ b/src/app/src/components/SeeTheFishway.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import update from 'immutability-helper';
 import { Flex, Box } from 'rebass';
+import { themeGet } from 'styled-system';
 import { Heading, Text } from './custom-styled-components';
 import styled from 'styled-components';
 
@@ -13,9 +14,38 @@ const StyledSeeTheFishway = styled(Flex)`
     height: 100%;
 `;
 
+const PageTitle = styled(Heading)`
+    margin-bottom: ${themeGet('space.small')};
+`;
+
 const SeeTheFishwayTray = styled(Flex)`
     flex-direction: column;
     width: 100%;
+    padding: ${themeGet('space.comfortable')};
+`;
+
+const Subtitle = styled(Heading)`
+    margin-top: ${themeGet('space.medium')};
+    margin-bottom: 0;
+`;
+
+const VideoCardButtonContainer = styled(Flex)`
+    flex-wrap: wrap;
+    margin-top: ${themeGet('space.medium')};
+
+    button {
+        flex: 0 0 14.15%;
+        margin: 0 3% ${themeGet('space.medium')} 0;
+        padding: 0;
+    }
+
+    button:nth-child(6n) {
+        margin: 0 0 ${themeGet('space.medium')};
+    }
+
+    img {
+        width: 100%;
+    }
 `;
 
 const VideoCardButton = styled.button`
@@ -56,26 +86,22 @@ const SeeTheFishway = () => {
         <StyledSeeTheFishway>
             <SeeTheFishwayTray>
                 <Box>
-                    <Heading as='h1'>See the Fishway</Heading>
+                    <PageTitle as='h1'>See the Fishway</PageTitle>
                     <Text as='p' variant='large'>
-                        During the Spring migration, a video camera transmits
-                        live images to this exhibit, and to aquatic biologists.
-                    </Text>
-                    <Text as='p'>
-                        Biologists monitor fish moving up and down the river. In
-                        Springtime, fish travel upriver to their spawning
-                        grounds, to mate and lay eggs. This is when the Fish
-                        Ladder is most active.
+                        In Springtime, fish travel upriver to their spawning
+                        grounds to mate and lay their eggs — this is when the
+                        fishway is bursting with activity. Biologists monitor
+                        the fish moving up and down the river.
                     </Text>
                 </Box>
-                <Heading as='h2' variant='small'>
+                <Subtitle as='h2' variant='small'>
                     Highlight reel
-                </Heading>
+                </Subtitle>
                 <Text as='p'>
                     Check out some of the wildlife that scientists have caught
                     on tape over the years.
                 </Text>
-                <Flex flexWrap='wrap'>{cards}</Flex>
+                <VideoCardButtonContainer>{cards}</VideoCardButtonContainer>
             </SeeTheFishwayTray>
             <Sidebar fish={selectedFish} />
         </StyledSeeTheFishway>

--- a/src/app/src/components/SeeTheFishway.js
+++ b/src/app/src/components/SeeTheFishway.js
@@ -42,10 +42,6 @@ const VideoCardButtonContainer = styled(Flex)`
     button:nth-child(6n) {
         margin: 0 0 ${themeGet('space.medium')};
     }
-
-    img {
-        width: 100%;
-    }
 `;
 
 const VideoCardButton = styled.button`

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -10,7 +10,6 @@ import { HighlightFish } from '../util/HighlightFish';
 
 import VideoPlayer from './VideoPlayer';
 import FishNames from './FishNames';
-import { LIVE_FEED_LABEL } from '../util/constants';
 
 const StyledSidebar = styled(Flex)`
     position: sticky;
@@ -71,27 +70,26 @@ const Sidebar = ({ fish }) => {
     // The fishway's live video camera sends a stream of JPEG images, not video
     // This is typical of digital cameras
     // All other videos are properly video files (.mp4)
-    const videoPlayer =
-        fish && commonName === LIVE_FEED_LABEL ? (
-            <LiveFeed>
-                <StyledLiveFeedHeading as='span' variant='xSmall'>
-                    <FontAwesomeIcon
-                        icon={['fas', 'video']}
-                        pull='left'
-                        size='lg'
-                    />
-                    Live
-                </StyledLiveFeedHeading>
-                <img
-                    src={video}
-                    alt='Live stream from the Schuylkill fishway'
-                    height='360px'
-                    width='360px'
+    const videoPlayer = fish.isLiveFeed ? (
+        <LiveFeed>
+            <StyledLiveFeedHeading as='span' variant='xSmall'>
+                <FontAwesomeIcon
+                    icon={['fas', 'video']}
+                    pull='left'
+                    size='lg'
                 />
-            </LiveFeed>
-        ) : (
-            <VideoPlayer src={video} />
-        );
+                Live
+            </StyledLiveFeedHeading>
+            <img
+                src={video}
+                alt='Live stream from the Schuylkill fishway'
+                height='360px'
+                width='360px'
+            />
+        </LiveFeed>
+    ) : (
+        <VideoPlayer src={video} />
+    );
     return (
         <StyledSidebar>
             <StyledFishNames

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Flex } from 'rebass';
-import { Text } from './custom-styled-components';
+import { Heading, Text } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 import moment from 'moment';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { HighlightFish } from '../util/HighlightFish';
 
@@ -31,6 +32,36 @@ const FooterNotes = styled(Text)`
     margin: 0 auto ${themeGet('space.compact')};
 `;
 
+const LiveFeed = styled(Flex)`
+    position: relative;
+    border-radius: 4px;
+    justify-content: center;
+    margin: 0 auto ${themeGet('space.compact')};
+    background: ${themeGet('colors.teals.4')};
+
+    img {
+        width: 30rem;
+        height: auto;
+        border-radius: 4px;
+        border: 2px solid ${themeGet('colors.teals.3')};
+        line-height: 0;
+    }
+`;
+
+const StyledLiveFeedHeading = styled(Heading)`
+    position: absolute;
+    left: 1rem;
+    top: 1rem;
+    display: flex;
+    align-items: center;
+    text-shadow: 0 0 4px rgba(0, 0, 0, 0.75);
+
+    svg {
+        color: ${themeGet('colors.red')};
+        text-shadow: 0 0 4px rgba(0, 0, 0, 0.75);
+    }
+`;
+
 const Sidebar = ({ fish }) => {
     const { commonName, scientificName, video, notes, timestamp } = fish;
     const date = moment(timestamp)
@@ -42,12 +73,22 @@ const Sidebar = ({ fish }) => {
     // All other videos are properly video files (.mp4)
     const videoPlayer =
         fish && commonName === LIVE_FEED_LABEL ? (
-            <img
-                src={video}
-                alt='Live stream from the Schuylkill fishway'
-                height='360px'
-                width='360px'
-            />
+            <LiveFeed>
+                <StyledLiveFeedHeading as='span' variant='xSmall'>
+                    <FontAwesomeIcon
+                        icon={['fas', 'video']}
+                        pull='left'
+                        size='lg'
+                    />
+                    Live
+                </StyledLiveFeedHeading>
+                <img
+                    src={video}
+                    alt='Live stream from the Schuylkill fishway'
+                    height='360px'
+                    width='360px'
+                />
+            </LiveFeed>
         ) : (
             <VideoPlayer src={video} />
         );

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box } from 'rebass';
+import { Flex } from 'rebass';
 import { Text } from './custom-styled-components';
 import { themeGet } from 'styled-system';
 import moment from 'moment';
@@ -11,10 +11,24 @@ import VideoPlayer from './VideoPlayer';
 import FishNames from './FishNames';
 import { LIVE_FEED_LABEL } from '../util/constants';
 
-const StyledSidebar = styled(Box)`
+const StyledSidebar = styled(Flex)`
+    position: sticky;
+    top: ${themeGet('navHeight')};
+    flex-direction: column;
+    justify-content: center;
     background: ${themeGet('colors.teals.5')};
     text-align: center;
-    width: 100%;
+    padding: 3.95rem ${themeGet('space.comfortable')};
+    height: calc(100vh - ${themeGet('navHeight')});
+`;
+
+const StyledFishNames = styled(FishNames)`
+    margin-bottom: ${themeGet('space.spacious')};
+`;
+
+const FooterNotes = styled(Text)`
+    max-width: ${themeGet('maxWidths.xsmall')};
+    margin: 0 auto ${themeGet('space.compact')};
 `;
 
 const Sidebar = ({ fish }) => {
@@ -39,14 +53,18 @@ const Sidebar = ({ fish }) => {
         );
     return (
         <StyledSidebar>
-            <FishNames
+            <StyledFishNames
                 commonName={commonName}
                 scientificName={scientificName}
             />
             {videoPlayer}
             <footer>
-                <Text variant='small'>{notes}</Text>
-                <Text variant='small'>{date}</Text>
+                <FooterNotes as='p' variant='small'>
+                    {notes}
+                </FooterNotes>
+                <Text as='p' variant='small'>
+                    {date}
+                </Text>
             </footer>
         </StyledSidebar>
     );

--- a/src/app/src/components/VideoCard.js
+++ b/src/app/src/components/VideoCard.js
@@ -3,10 +3,14 @@ import styled from 'styled-components';
 import { themeGet } from 'styled-system';
 
 const StyledVideoCard = styled('img')(props => ({
-    borderRadius: '100px',
-    border: props.selected
-        ? `${themeGet('colors.greens.1')(props)} 3px solid`
-        : 'none',
+    borderRadius: '4px',
+    boxShadow: props.selected
+        ? `0 0 0 1px ${themeGet('colors.teals.0')(props)}, 0 0 0 4px ${themeGet(
+              'colors.greens.1'
+          )(props)}`
+        : `0 0 0 2px ${themeGet('colors.teals.0')(props)}`,
+    transform: props.selected ? `scale(1.05)` : 'scale(1)',
+    transition: 'all 0.25s cubic-bezier(.1,.2,.75,.19)',
 }));
 
 const VideoCard = ({ fish, selected }) => {

--- a/src/app/src/components/VideoCard.js
+++ b/src/app/src/components/VideoCard.js
@@ -1,10 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Box } from 'rebass';
+import { Heading } from './custom-styled-components';
 import { themeGet } from 'styled-system';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const StyledBox = styled(Box)`
+    position: relative;
+`;
 
 const StyledVideoCard = styled('img')(props => ({
-    height: 'auto',
     borderRadius: '4px',
+    width: '100%',
+    height: 'auto',
     boxShadow: props.selected
         ? `0 0 0 1px ${themeGet('colors.teals.0')(props)}, 0 0 0 4px ${themeGet(
               'colors.greens.1'
@@ -14,15 +22,51 @@ const StyledVideoCard = styled('img')(props => ({
     transition: 'all 0.25s cubic-bezier(.1,.2,.75,.19)',
 }));
 
+const StyledLiveFeedHeading = styled(Heading)`
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    align-items: center;
+    text-shadow: 0 0 4px rgba(0, 0, 0, 0.75);
+    z-index: 1;
+    white-space: nowrap;
+    text-align: center;
+
+    svg {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+    }
+`;
+
 const VideoCard = ({ fish, selected }) => {
     return (
-        <StyledVideoCard
-            src={fish.photo}
-            height='122px'
-            width='122px'
-            alt={fish.commonName}
-            selected={selected}
-        />
+        <StyledBox>
+            {(() => {
+                if (fish.isLiveFeed === true)
+                    return (
+                        <StyledLiveFeedHeading as='span' variant='xSmall'>
+                            <FontAwesomeIcon
+                                icon={['fas', 'video']}
+                                pull='left'
+                                size='4x'
+                                opacity='0.3'
+                            />
+                            Live Feed
+                        </StyledLiveFeedHeading>
+                    );
+            })()}
+            <StyledVideoCard
+                src={fish.photo}
+                alt={fish.commonName}
+                width='122'
+                height='122'
+                selected={selected}
+            />
+        </StyledBox>
     );
 };
 

--- a/src/app/src/components/VideoCard.js
+++ b/src/app/src/components/VideoCard.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { themeGet } from 'styled-system';
 
 const StyledVideoCard = styled('img')(props => ({
+    height: 'auto',
     borderRadius: '4px',
     boxShadow: props.selected
         ? `0 0 0 1px ${themeGet('colors.teals.0')(props)}, 0 0 0 4px ${themeGet(

--- a/src/app/src/components/VideoCard.js
+++ b/src/app/src/components/VideoCard.js
@@ -43,22 +43,20 @@ const StyledLiveFeedHeading = styled(Heading)`
 `;
 
 const VideoCard = ({ fish, selected }) => {
+    const liveVideoHeading = (
+        <StyledLiveFeedHeading as='span' variant='xSmall'>
+            <FontAwesomeIcon
+                icon={['fas', 'video']}
+                pull='left'
+                size='4x'
+                opacity='0.3'
+            />
+            Live Feed
+        </StyledLiveFeedHeading>
+    );
     return (
         <StyledBox>
-            {(() => {
-                if (fish.isLiveFeed === true)
-                    return (
-                        <StyledLiveFeedHeading as='span' variant='xSmall'>
-                            <FontAwesomeIcon
-                                icon={['fas', 'video']}
-                                pull='left'
-                                size='4x'
-                                opacity='0.3'
-                            />
-                            Live Feed
-                        </StyledLiveFeedHeading>
-                    );
-            })()}
+            {fish.isLiveFeed && liveVideoHeading}
             <StyledVideoCard
                 src={fish.photo}
                 alt={fish.commonName}

--- a/src/app/src/components/VideoPlayer.js
+++ b/src/app/src/components/VideoPlayer.js
@@ -11,8 +11,74 @@ import { Button } from './custom-styled-components';
 import Video from './Video';
 
 const PlayButton = styled(Button)`
-    color: '#fff';
+    color: ${themeGet('colors.white')};
     font-size: ${themeGet('fontSizes.3')};
+    padding: ${themeGet('space.compact')} ${themeGet('space.compact')}
+        ${themeGet('space.compact')} 0;
+`;
+
+const Controls = styled(Flex)`
+    align-items: center;
+`;
+
+const StyledSlider = styled(Slider)`
+    padding-right: ${themeGet('space.compact')};
+
+    .rc-slider {
+        height: 20px;
+    }
+
+    .rc-slider-track,
+    .rc-slider-rail {
+        height: 8px;
+    }
+
+    .rc-slider-track {
+        background: ${themeGet('colors.teals.0')};
+    }
+
+    .rc-slider-rail {
+        background: ${themeGet('colors.teals.3')};
+    }
+
+    .rc-slider-handle {
+        width: 1.5rem;
+        height: 1.5rem;
+        margin-left: -0.55rem;
+        margin-top: -0.5rem;
+        border: 2px solid ${themeGet('colors.teals.6')};
+    }
+
+    .rc-slider-handle::after {
+        content: '';
+        display: block;
+        background: linear-gradient(
+            -45deg,
+            rgb(265, 265, 265) 0%,
+            rgb(165, 187, 195) 100%
+        );
+        height: 0.8rem;
+        width: 0.8rem;
+        margin-top: 50%;
+        margin-left: 50%;
+        transform: translate(-50%, -50%);
+        z-index: 1;
+        border-radius: 100%;
+    }
+
+    .rc-slider-handle:active,
+    .rc-slider-handle:focus,
+    .rc-slider-handle-click-focused:focus {
+        border: 2px solid ${themeGet('colors.lightblues.2')};
+        box-shadow: 0 0 2px 2px ${themeGet('colors.teals.6')};
+    }
+`;
+
+const StyledVideo = styled(Video)`
+    width: 30rem;
+    border-radius: 4px;
+    border: 2px solid ${themeGet('colors.teals.3')};
+    line-height: 0;
 `;
 
 const VideoPlayer = ({ src }) => {
@@ -25,7 +91,7 @@ const VideoPlayer = ({ src }) => {
 
     return (
         <Flex flexDirection='column'>
-            <Video
+            <StyledVideo
                 src={src}
                 autoPlay={true}
                 setref={videoRef}
@@ -41,7 +107,7 @@ const VideoPlayer = ({ src }) => {
                     setVideoTime(1);
                 }}
             />
-            <Flex>
+            <Controls>
                 <PlayButton
                     variant='link'
                     onClick={() => {
@@ -55,7 +121,7 @@ const VideoPlayer = ({ src }) => {
                 >
                     <FontAwesomeIcon icon={['fas', icon]} />
                 </PlayButton>
-                <Slider
+                <StyledSlider
                     max={1}
                     step={0.01}
                     value={videoTime}
@@ -72,18 +138,8 @@ const VideoPlayer = ({ src }) => {
                                 percent * videoElem.duration;
                         }
                     }}
-                    onAfterChange={percent => {
-                        // Don't play the video if the scrubber was dragged to
-                        // the end, otherwise it will *restart*
-                        if (percent !== 1) {
-                            if (videoRef.current) {
-                                videoRef.current.play();
-                            }
-                            setIsPlaying(true);
-                        }
-                    }}
                 />
-            </Flex>
+            </Controls>
         </Flex>
     );
 };

--- a/src/app/src/components/VideoPlayer.js
+++ b/src/app/src/components/VideoPlayer.js
@@ -47,6 +47,18 @@ const StyledSlider = styled(Slider)`
         margin-left: -0.55rem;
         margin-top: -0.5rem;
         border: 2px solid ${themeGet('colors.teals.6')};
+        position: relative;
+    }
+
+    .rc-slider-handle::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: -1.5rem;
+        right: -1.5rem;
+        bottom: -1.5rem;
+        left: -1.5rem;
+        border-radius: 100%;
     }
 
     .rc-slider-handle::after {

--- a/src/app/src/util/HighlightFish.js
+++ b/src/app/src/util/HighlightFish.js
@@ -1,4 +1,4 @@
-import { shape, string, number } from 'prop-types';
+import { shape, string, number, bool } from 'prop-types';
 
 export const HighlightFish = shape({
     commonName: string.isRequired,
@@ -6,4 +6,5 @@ export const HighlightFish = shape({
     picturePath: string,
     timestamp: number.isRequired,
     notes: string.isRequired,
+    isLiveFeed: bool,
 });

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -213,6 +213,7 @@ export const LIVE_FEED_MOCK_FISH = {
     timestamp: new Date().getTime(),
     video: LIVE_FEED_URL,
     photo: LIVE_FEED_URL,
+    isLiveFeed: true,
     notes:
         'A video camera in the fishway captures live video for this exhibit. Watch carefully and you may see someone swimming by!',
 };

--- a/src/app/src/util/theme.js
+++ b/src/app/src/util/theme.js
@@ -67,6 +67,7 @@ export default {
         large: '8rem',
     },
     maxWidths: {
+        xsmall: '30rem',
         small: '42.875rem',
         wide: '104.500rem',
     },

--- a/src/app/src/util/theme.js
+++ b/src/app/src/util/theme.js
@@ -1,4 +1,5 @@
 export default {
+    navHeight: '5rem',
     breakpoints: {
         small: '40em',
         medium: '52em',
@@ -41,13 +42,13 @@ export default {
         greens: ['#e9f563', '#CEE007', '#c1d12f', '#a0af04'],
         red: '#C5603B',
         teals: [
-            '#296882',
-            '#205064',
-            '#1b4455',
-            '#163846',
-            '#112c37',
-            '#0d2029',
-            '#010d13',
+            '#296882', // 0
+            '#205064', // 1
+            '#1b4455', // 2
+            '#163846', // 3
+            '#112c37', // 4
+            '#0d2029', // 5
+            '#010d13', // 6
         ],
         xlighttan: '#fffdf9',
         lighttan: '#FBF8F4',


### PR DESCRIPTION
## Overview
A style pass of See the Fishway.

Connects #93

### Demo
<img width="1792" alt="Screen Shot 2019-07-05 at 2 01 54 PM" src="https://user-images.githubusercontent.com/5672295/60739035-5c751600-9f2e-11e9-8df3-d9f7e2ad0619.png">


### Notes
- There's an error that I'm seeing on `develop` as well as this branch... but not on staging: 
```
Warning: Failed prop type: The prop `fish.path` is marked as required in `Sidebar`, but its value is `undefined`.
```
- The scrubber was set to replay when the user moved the track handle. This pattern felt strange to me, so I removed the code that did this. When the user interacts with the scrubber, it pauses and stays paused until they hit the play button. 
- It looks like there are more videos here than in the current app (which has 9)—
<img width="878" alt="Screen Shot 2019-07-05 at 1 59 58 PM" src="https://user-images.githubusercontent.com/5672295/60738692-356a1480-9f2d-11e9-8c52-9404f4d1b40e.png"> If we can remove some of them, that would be great so that they can all fit comfortably on the screen. I would then alter the code slightly to accommodate.
- It would be nice if the latin name for each "fish" weren't required, so that we could hide the placeholder shown here entirely, but I'm not sure how to do this. Should I enter another issue? It seems like a detail that we could save for the end of the project: <img width="614" alt="Screen Shot 2019-07-05 at 2 05 53 PM" src="https://user-images.githubusercontent.com/5672295/60738996-394a6680-9f2e-11e9-902b-ed72da33b14b.png">
- I _think_ I can't style the live version yet until we do #74. Created #108 to cover this work.


## Testing Instructions
* git pull
* Go to See the Fishway tab
* Select different videos by their button
* Play with scrubber, note that the video stops playing once the scrubber is interacted with and doesn't play again without the user clicking the play button.
