### PR TITLE
Add live feed feature of SeeTheFishway

### DIFF
--- a/src/app/src/components/FishNames.js
+++ b/src/app/src/components/FishNames.js
@@ -33,7 +33,7 @@ const FishNames = ({ commonName, scientificName }) => {
 
 FishNames.propTypes = {
     commonName: string.isRequired,
-    scientificName: string.isRequired,
+    scientificName: string,
 };
 
 export default FishNames;

--- a/src/app/src/components/QuizQuestion.js
+++ b/src/app/src/components/QuizQuestion.js
@@ -57,7 +57,7 @@ class QuizQuestion extends React.Component {
         const { guessed, usedHint } = this.state;
 
         const showHint = guessed.length > 0 || usedHint;
-        // TODO: Remove the default value here when we get hint text
+        // TODO (Issue #96): Remove the default value here when we get hint text
         let hint = showHint
             ? answer.hint || `its ${answer.commonName}`
             : 'Get a hint';

--- a/src/app/src/components/SeeTheFishway.js
+++ b/src/app/src/components/SeeTheFishway.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
+import update from 'immutability-helper';
 import { Flex, Box } from 'rebass';
 import { Heading, Text } from './custom-styled-components';
 import styled from 'styled-components';
 
-import { FISH_HIGHLIGHTS } from '../util/constants';
+import { FISH_HIGHLIGHTS, LIVE_FEED_MOCK_FISH } from '../util/constants';
 
 import Sidebar from './Sidebar';
 import VideoCard from './VideoCard';
@@ -28,10 +29,21 @@ const VideoCardButton = styled.button`
 `;
 
 const SeeTheFishway = () => {
-    const [selectedFish, selectFish] = useState(FISH_HIGHLIGHTS[0]);
+    let fishList = FISH_HIGHLIGHTS;
 
-    const cards = FISH_HIGHLIGHTS.map(fish => (
-        <VideoCardButton key={fish.timestamp} onClick={() => selectFish(fish)}>
+    // Fish migration season is June through August
+    const currentMonth = new Date().getMonth();
+    if (currentMonth > 5 && currentMonth < 8) {
+        // TODO (Issue #77): check if the stream works else don't show the option
+        fishList = update(FISH_HIGHLIGHTS, {
+            $unshift: [LIVE_FEED_MOCK_FISH],
+        });
+    }
+
+    const [selectedFish, selectFish] = useState(fishList[0]);
+
+    const cards = fishList.map(fish => (
+        <VideoCardButton key={fish.notes} onClick={() => selectFish(fish)}>
             <VideoCard
                 fish={fish}
                 selected={

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -9,6 +9,7 @@ import { HighlightFish } from '../util/HighlightFish';
 
 import VideoPlayer from './VideoPlayer';
 import FishNames from './FishNames';
+import { LIVE_FEED_LABEL } from '../util/constants';
 
 const StyledSidebar = styled(Box)`
     background: ${themeGet('colors.teals.5')};
@@ -21,7 +22,21 @@ const Sidebar = ({ fish }) => {
     const date = moment(timestamp)
         .format('MMMM Do')
         .toUpperCase();
-    const videoPlayer = fish && <VideoPlayer src={video} />;
+
+    // The fishway's live video camera sends a stream of JPEG images, not video
+    // This is typical of digital cameras
+    // All other videos are properly video files (.mp4)
+    const videoPlayer =
+        fish && commonName === LIVE_FEED_LABEL ? (
+            <img
+                src={video}
+                alt='Live stream from the Schuylkill fishway'
+                height='360px'
+                width='360px'
+            />
+        ) : (
+            <VideoPlayer src={video} />
+        );
     return (
         <StyledSidebar>
             <FishNames

--- a/src/app/src/components/VideoCard.js
+++ b/src/app/src/components/VideoCard.js
@@ -13,6 +13,8 @@ const VideoCard = ({ fish, selected }) => {
     return (
         <StyledVideoCard
             src={fish.photo}
+            height='122px'
+            width='122px'
             alt={fish.commonName}
             selected={selected}
         />

--- a/src/app/src/util/HighlightFish.js
+++ b/src/app/src/util/HighlightFish.js
@@ -2,8 +2,8 @@ import { shape, string, number } from 'prop-types';
 
 export const HighlightFish = shape({
     commonName: string.isRequired,
-    scientificName: string.isRequired,
-    picturePath: string.isRequired,
+    scientificName: string,
+    picturePath: string,
     timestamp: number.isRequired,
     notes: string.isRequired,
 });

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -206,6 +206,17 @@ const BLUEGILL = {
     picturePath: bluegillIllustration,
 };
 
+export const LIVE_FEED_LABEL = 'See what scientists see';
+export const LIVE_FEED_URL = 'http://184.80.36.103/axis-cgi/mjpg/video.cgi'; // TODO: Replace with IP of fishway camera
+export const LIVE_FEED_MOCK_FISH = {
+    commonName: LIVE_FEED_LABEL,
+    timestamp: new Date().getTime(),
+    video: LIVE_FEED_URL,
+    photo: LIVE_FEED_URL,
+    notes:
+        'A video camera in the fishway captures live video for this exhibit. Watch carefully and you may see someone swimming by!',
+};
+
 export const FISH_HIGHLIGHTS = [
     {
         ...AMERICAN_SHAD,
@@ -263,7 +274,6 @@ export const FISH_HIGHLIGHTS = [
     },
     {
         commonName: 'Turtle',
-        scientificName: '—',
         video: turtleVideo,
         photo: turtlePhoto,
         timestamp: 1114119720000,
@@ -272,7 +282,6 @@ export const FISH_HIGHLIGHTS = [
     },
     {
         commonName: 'Snake',
-        scientificName: '—',
         video: snakeVideo,
         photo: snakePhoto,
         timestamp: 1115907780000,


### PR DESCRIPTION
## Overview

Prepare the app to accomodate the AXIS camera public IP live feed of the Fishway. Said feed won't be available until the camera is installed tentatively for the 2020 fish migration season. This work was done now rather than in the future to ensure the app is prepared, and save on mental spin up time later.

For demonstration purposes now, use some AXIS public IP video stream. 

This PR is for demonstration. We can let this branch hang out until the time comes to implement, or merge with commented out logic to add the live feed video. I prefer the latter so the code doesn't get hit with merge conflicts in the future.

Left some TODO's for future tasks.

Connects #74

### Demo

![bees!](https://user-images.githubusercontent.com/10568752/61000688-f6243500-a32b-11e9-8a64-d50dbd5f3028.gif)


### Notes
This admittedly feels a little hacky in order to hook into the existing components. 

Apparently the internet connection in the museum is spotty. I don't know how we'll handle that case yet, but there's #77 for that scope of work. For now, alt text will show but that is not ideal for a regular case situation.

Because the video feed is consumed as an `img` tag, surprisingly, I was able to slot it in for the video card. We may just want a static image, as is in the wireframes: https://share.goabstract.com/30adce0d-84b1-4c07-bd65-84ecdaf7ee52?collectionLayerId=464d2428-17a2-4d2c-b769-e14ccb4ab397&mode=design

## Testing Instructions

Check out the See The Fishway tab and see the live feed. It shows up and is automatically selected because it is June-August right now.