### PR TITLE
Ignore subset of mouse/touch behaviors to prevent undesirable behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ vagrant ssh
 ./scripts/server
 ```
 
+### Optimizing the browser for touchscreen mode
+The website hosted at the FWW Museum will be displayed on an ELO touchscreen of 1920 x 1080 screen size, on the latest version of Chrome at the time of initial deployment, on a Windows 10 Pro computer. Windows and Chrome have a lot of built-in touch-initiated interactions that are sub-optimal for the museum display. For example, we don't want activity from pinch-zoom, long taps, or hard left/right swipes. Chrome and Windows allows customization for some of these behaviors and Chrome does save settings. At the time of install, these should be set up:
+- [ ] Windows in Tablet mode
+- [ ] Windows launch Chrome at startup
+- [ ] Windows disable screen edge touch interactions
+  - Windows group policy > Computer Configuration > Windows Components > Edge UI > Disable all
+- [ ] Chrome fullscreen, full window (F11)
+- [ ] Chrome settings, open at the production site
+- [ ] Chrome flags at `chrome://flags`
+  - *Touch UI Layout* set to **Enabled**
+  - *Overscroll history navigation* set to **Disabled**
+  - *Overscroll history navigation on Touchpad* set to **Disabled**
+  - *Passive Event Listener Override* set to **True**
+  - *Document Level Event Listeners Passive Default* set to **Enabled**
+  - *Touch adjustment* set to **Enabled**
+
+
 ### Ports
 
 | Service            | Port                            |

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -72,6 +72,12 @@ class App extends Component {
         this.idleTimer = null;
         this.resetTimer = this.resetTimer.bind(this);
         this.pauseTimer = this.pauseTimer.bind(this);
+
+        window.oncontextmenu = event => {
+            event.preventDefault();
+            event.stopPropagation();
+            return false;
+        };
     }
 
     componentDidUpdate(prevProps) {

--- a/src/app/src/util/globalStyle.js
+++ b/src/app/src/util/globalStyle.js
@@ -77,6 +77,7 @@ const GlobalStyle = createGlobalStyle`
     .App, 
     .App >div {
         height: 100%;
+        touch-action: none; /*disable pinching, panning*/
     }
 
     .tab-pane[aria-hidden='true'] {


### PR DESCRIPTION
## Overview

A website in Chrome is not optimized for a museum display nor touchscreen by default. Chrome, and Windows, come built in with click and swipe interactions that can cause undesirable behavior to a museum user. We are able to use code and browser settings to manage these issues rather than rely on a 3rd party service like kiosk to try to host the app natively or otherwise. Some of the addressed behaviors are informed by the current app that educators and the client report as broken. Some undesirable touchscreen + browser behaviors such as overscroll are set by Chrome itself and are not part of this PR. 

Connects #17

### Notes
Mildly annoying but livable, there's no more right click. So for a developer to open browser inspection tools they'll have to use the browser dropdowns or shortcut.

## Testing Instructions

Test out this PR on the ELO touchscreen! That's the best option. Otherwise, tablet mode in Chrome should be pretty comparable.
