### PR TITLE
Videos correctly pause timer while playing

### DIFF
--- a/src/app/src/components/Video.js
+++ b/src/app/src/components/Video.js
@@ -5,24 +5,40 @@ import { func } from 'prop-types';
 import { pauseTimer, resetTimer } from '../actions';
 
 const Video = props => {
-    const { dispatch, setref, onPlay, onPause, onEnded, ...otherProps } = props;
+    const {
+        dispatch,
+        setref,
+        onPlay,
+        onPause,
+        onEnded,
+        autoPlay,
+        ...otherProps
+    } = props;
+
+    const dispatchIfActiveVideo = action => {
+        // autoPlay is an indicator of the video being actively shown to the user
+        // in some cases, only the active video should update the global state
+        if (autoPlay) {
+            return dispatch(action());
+        }
+    };
 
     return (
         <video
             onPlay={() => {
-                dispatch(pauseTimer());
+                dispatchIfActiveVideo(pauseTimer);
                 if (onPlay) {
                     onPlay();
                 }
             }}
             onPause={() => {
-                dispatch(resetTimer());
+                dispatchIfActiveVideo(resetTimer);
                 if (onPause) {
                     onPause();
                 }
             }}
             onEnded={() => {
-                dispatch(resetTimer());
+                dispatchIfActiveVideo(resetTimer);
                 if (onEnded) {
                     onEnded();
                 }


### PR DESCRIPTION
## Overview

During RRP demo 😢we discovered a bug whereby in the middle of watching an About video, the screensaver appeared. That was a bug in the video/app timer interaction which this PR addresses.

Connects #79 

### Demo

Buggy log whereby panning forward or back fired video actions in the opposite order:
<img width="355" alt="Screen Shot 2019-07-12 at 12 28 17 PM" src="https://user-images.githubusercontent.com/10568752/61143659-d8c4a780-a4a0-11e9-8f0c-de1f5606b48a.png">



Current action log whereby only the active video fires an action:
<img width="344" alt="Screen Shot 2019-07-12 at 12 27 55 PM" src="https://user-images.githubusercontent.com/10568752/61143723-fd208400-a4a0-11e9-95bb-d09cd1518a0d.png">

## Notes
The actions are cleaned up except when a video ends -- the `video` HTML element fires both pause and end actions, so `resetTimer` is fired twice. I think this is fine enough.

## Testing Instructions

Pan forward and back in the About slide 
--> netlify: pan forward then back to a slide, and let the video play through -- you shouldn't see the screensaver. when the video ends, the reset timer action should be fired
--> if locally: see that the correct action(s) are fired per the React logs
