### PR TITLE
Set up a back up plan for showing the live feed when the internet disconnects

### DIFF
--- a/src/app/src/actions.js
+++ b/src/app/src/actions.js
@@ -14,3 +14,6 @@ export const saveSecondsToCompleteQuiz = createAction(
 );
 export const setBackgroundPosition = createAction('Set Background position');
 export const setActiveTab = createAction('Set active tab');
+export const showConnectionErrorMessage = createAction(
+    'Henceforth show error message for live feed when disconnected from the internet'
+);

--- a/src/app/src/components/FishNames.js
+++ b/src/app/src/components/FishNames.js
@@ -8,6 +8,7 @@ import { Heading, Text } from './custom-styled-components';
 
 const StyledFishNames = styled(Flex)`
     flex-direction: column;
+    margin-bottom: ${props => themeGet(`${props.spacing}`, 0)};
 `;
 
 const CommonName = styled(Heading)`

--- a/src/app/src/components/QuizSidebar.js
+++ b/src/app/src/components/QuizSidebar.js
@@ -12,7 +12,9 @@ const StyledQuizSidebar = styled(Box)`
 `;
 
 const QuizSidebar = ({ fish }) => {
-    const video = fish && <VideoPlayer src={fish.videoPath} />;
+    const video = fish && (
+        <VideoPlayer src={fish.videoPath} key={fish.videoPath} />
+    );
     return (
         <StyledQuizSidebar>
             <Heading as='h2' variant='small'>

--- a/src/app/src/components/SeeTheFishway.js
+++ b/src/app/src/components/SeeTheFishway.js
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { bool } from 'prop-types';
-import update from 'immutability-helper';
 import { Flex, Box } from 'rebass';
 import { themeGet } from 'styled-system';
 import { Heading, Text } from './custom-styled-components';
 import styled from 'styled-components';
 
-import { FISH_HIGHLIGHTS, LIVE_FEED_MOCK_FISH } from '../util/constants';
+import { FISH_HIGHLIGHTS } from '../util/constants';
 
 import Sidebar from './Sidebar';
 import VideoCard from './VideoCard';
@@ -60,6 +59,16 @@ const SeeTheFishway = ({ showConnectionError }) => {
     let fishList = FISH_HIGHLIGHTS;
 
     // Fish migration season is June through August
+    /*
+
+    **********************************************************
+    Uncomment this section and update imports to reinstate the
+    live feed feature. Pending the public IP Axis camera
+    installation at the Fishway.
+
+    TODO: https://github.com/azavea/pwd-fishway/issues/122
+    **********************************************************
+
     const currentMonth = new Date().getMonth();
     if (
         currentMonth > 5 &&
@@ -70,6 +79,7 @@ const SeeTheFishway = ({ showConnectionError }) => {
             $unshift: [LIVE_FEED_MOCK_FISH],
         });
     }
+    */
 
     const [selectedFish, selectFish] = useState(fishList[0]);
 

--- a/src/app/src/components/SeeTheFishway.js
+++ b/src/app/src/components/SeeTheFishway.js
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import { bool } from 'prop-types';
 import update from 'immutability-helper';
 import { Flex, Box } from 'rebass';
 import { themeGet } from 'styled-system';
@@ -54,13 +56,16 @@ const VideoCardButton = styled.button`
     }
 `;
 
-const SeeTheFishway = () => {
+const SeeTheFishway = ({ showConnectionError }) => {
     let fishList = FISH_HIGHLIGHTS;
 
     // Fish migration season is June through August
     const currentMonth = new Date().getMonth();
-    if (currentMonth > 5 && currentMonth < 8) {
-        // TODO (Issue #77): check if the stream works else don't show the option
+    if (
+        currentMonth > 5 &&
+        currentMonth < 8 &&
+        (navigator.onLine || showConnectionError)
+    ) {
         fishList = update(FISH_HIGHLIGHTS, {
             $unshift: [LIVE_FEED_MOCK_FISH],
         });
@@ -104,4 +109,14 @@ const SeeTheFishway = () => {
     );
 };
 
-export default SeeTheFishway;
+SeeTheFishway.propTypes = {
+    showConnectionError: bool.isRequired,
+};
+
+function mapStateToProps(state) {
+    return {
+        showConnectionError: state.showConnectionError,
+    };
+}
+
+export default connect(mapStateToProps)(SeeTheFishway);

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -123,7 +123,7 @@ class Sidebar extends Component {
                 );
             }
         } else {
-            videoPlayer = <VideoPlayer src={video} />;
+            videoPlayer = <VideoPlayer src={video} key={video} />;
         }
         return (
             <StyledSidebar>

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
+import { bool, func } from 'prop-types';
+import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { Flex } from 'rebass';
 import { Heading, Text } from './custom-styled-components';
@@ -10,6 +12,7 @@ import { HighlightFish } from '../util/HighlightFish';
 
 import VideoPlayer from './VideoPlayer';
 import FishNames from './FishNames';
+import { showConnectionErrorMessage } from '../actions';
 
 const StyledSidebar = styled(Flex)`
     position: sticky;
@@ -20,10 +23,6 @@ const StyledSidebar = styled(Flex)`
     text-align: center;
     padding: 3.95rem ${themeGet('space.comfortable')};
     height: calc(100vh - ${themeGet('navHeight')});
-`;
-
-const StyledFishNames = styled(FishNames)`
-    margin-bottom: ${themeGet('space.spacious')};
 `;
 
 const FooterNotes = styled(Text)`
@@ -47,6 +46,10 @@ const LiveFeed = styled(Flex)`
     }
 `;
 
+const LiveFeedError = styled(Flex)`
+    height: 360px;
+`;
+
 const StyledLiveFeedHeading = styled(Heading)`
     position: absolute;
     left: 1rem;
@@ -61,56 +64,99 @@ const StyledLiveFeedHeading = styled(Heading)`
     }
 `;
 
-const Sidebar = ({ fish }) => {
-    const { commonName, scientificName, video, notes, timestamp } = fish;
-    const date = moment(timestamp)
-        .format('MMMM Do')
-        .toUpperCase();
+class Sidebar extends Component {
+    constructor(props) {
+        super(props);
+        this.logLiveFeedError = this.logLiveFeedError.bind(this);
+        window.addEventListener('offline', this.logLiveFeedError);
+    }
 
-    // The fishway's live video camera sends a stream of JPEG images, not video
-    // This is typical of digital cameras
-    // All other videos are properly video files (.mp4)
-    const videoPlayer = fish.isLiveFeed ? (
-        <LiveFeed>
-            <StyledLiveFeedHeading as='span' variant='xSmall'>
-                <FontAwesomeIcon
-                    icon={['fas', 'video']}
-                    pull='left'
-                    size='lg'
+    logLiveFeedError() {
+        const { dispatch } = this.props;
+        dispatch(showConnectionErrorMessage());
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('offline', this.logLiveFeedError);
+    }
+
+    render() {
+        const { fish, showConnectionError } = this.props;
+        const { commonName, scientificName, video, notes, timestamp } = fish;
+        const date = moment(timestamp)
+            .format('MMMM Do')
+            .toUpperCase();
+
+        let videoPlayer = null;
+        if (fish.isLiveFeed) {
+            // For best UX, show the user a live feed error message if the internet connection fails while viewing SeeTheFishway
+            // Otherwise, hide the live feed until internet-connected so the user doesn't feel like they're missing something
+            if (navigator.onLine) {
+                videoPlayer = (
+                    <LiveFeed>
+                        <StyledLiveFeedHeading as='span' variant='xSmall'>
+                            <FontAwesomeIcon
+                                icon={['fas', 'video']}
+                                pull='left'
+                                size='lg'
+                            />
+                            Live
+                        </StyledLiveFeedHeading>
+                        {/*The fishway's live video camera sends a stream of JPEG images, not video.
+                            This is typical of digital cameras. All other videos are proper video files (.mp4) */}
+                        <img
+                            src={video}
+                            alt='Live stream from the Schuylkill fishway'
+                            height='360px'
+                            width='360px'
+                        />
+                    </LiveFeed>
+                );
+            } else if (showConnectionError) {
+                videoPlayer = (
+                    <LiveFeedError>
+                        <Text>
+                            Oops! There's a problem connecting to the live
+                            camera. Try again later!
+                        </Text>
+                    </LiveFeedError>
+                );
+            }
+        } else {
+            videoPlayer = <VideoPlayer src={video} />;
+        }
+        return (
+            <StyledSidebar>
+                <FishNames
+                    spacing='spacious'
+                    commonName={commonName}
+                    scientificName={scientificName}
                 />
-                Live
-            </StyledLiveFeedHeading>
-            <img
-                src={video}
-                alt='Live stream from the Schuylkill fishway'
-                height='360px'
-                width='360px'
-            />
-        </LiveFeed>
-    ) : (
-        <VideoPlayer src={video} />
-    );
-    return (
-        <StyledSidebar>
-            <StyledFishNames
-                commonName={commonName}
-                scientificName={scientificName}
-            />
-            {videoPlayer}
-            <footer>
-                <FooterNotes as='p' variant='small'>
-                    {notes}
-                </FooterNotes>
-                <Text as='p' variant='small'>
-                    {date}
-                </Text>
-            </footer>
-        </StyledSidebar>
-    );
-};
+                {videoPlayer}
+                <footer>
+                    <FooterNotes as='p' variant='small'>
+                        {notes}
+                    </FooterNotes>
+                    <Text as='p' variant='small'>
+                        {date}
+                    </Text>
+                </footer>
+            </StyledSidebar>
+        );
+    }
+}
 
 Sidebar.propTypes = {
     fish: HighlightFish.isRequired,
+    showConnectionError: bool.isRequired,
+    dispatch: func.isRequired,
 };
 
-export default Sidebar;
+function mapStateToProps(state) {
+    return {
+        showConnectionError: state.showConnectionError,
+        dispatch: state.dispatch,
+    };
+}
+
+export default connect(mapStateToProps)(Sidebar);

--- a/src/app/src/components/Video.js
+++ b/src/app/src/components/Video.js
@@ -44,6 +44,7 @@ const Video = props => {
                 }
             }}
             ref={setref}
+            autoPlay={autoPlay}
             {...otherProps}
         />
     );

--- a/src/app/src/reducers.js
+++ b/src/app/src/reducers.js
@@ -14,6 +14,7 @@ import {
     saveSecondsToCompleteQuiz,
     setBackgroundPosition,
     setActiveTab,
+    showConnectionErrorMessage,
 } from './actions';
 import { RESET, PAUSE, ABOUT } from './util/constants';
 
@@ -26,6 +27,7 @@ export const initialState = {
     quizScore: 0,
     secondsToCompleteQuiz: 0,
     activeTab: ABOUT,
+    showConnectionError: false,
 };
 
 export default createReducer(
@@ -51,6 +53,8 @@ export default createReducer(
             update(state, { backgroundPosition: { $set: payload } }),
         [setActiveTab]: (state, payload) =>
             update(state, { activeTab: { $set: payload } }),
+        [showConnectionErrorMessage]: state =>
+            update(state, { showConnectionError: { $set: true } }),
     },
     initialState
 );


### PR DESCRIPTION
## Overview

The museum wifi is supposedly spotty. The app operates offline, except for the live video feed feature which streams jpeg images from the fishway camera. We'll want to handle if the internet cuts out during a user session. 

1. User enters the See The Fishway tab for the first time and is offline --> don't show the live feed feature at all. Rationale: Don't tempt a user with features they can't access when not necessary.
  --> If the app connects to the internet while in this view, show the live feed as an option: a little abrupt and confusing perhaps, but gives the user full features avail.
2. User is on the See The Fishway tab when the internet disconnects --> present the live feed option still, but show an error message
3. The User has seen the error and revisits the tab --> always show the live feed option or the error because cat's out of the bag on it and the use should get consistent messaging

Connects #77 

### Demo

These gifs don't capture the app at its correct dimensions, so ignore styling.

Case 1
![offline_to_online](https://user-images.githubusercontent.com/10568752/61324029-742a8500-a7df-11e9-9692-d688d08660a7.gif)

Case 2
![online_to_offline](https://user-images.githubusercontent.com/10568752/61324021-6c6ae080-a7df-11e9-8ff9-f36969f699fd.gif)

Case 3
![error_msg_persists](https://user-images.githubusercontent.com/10568752/61324043-7d1b5680-a7df-11e9-9add-68a4c108ec90.gif)


### Notes

I thought that the `onError` event listener avail to the `img` tag to detect a dropped photo stream would be the winning path forward, but that event listener never fired when the wifi was cut.

The error message is pretty placeholder. Talked through this with @alexelash and believe she'll style it later.

Sometimes, particularly when the live feed comes back online, the image is frozen for quite some time. Sometimes it comes back speedily. I don't know why this is exactly, but it is not ideal :/

## Testing Instructions

Test locally because of CORS issues with the ip streaming on Netlify.
To test the 3 cases, and any other you may think of, turn off/on your computer wifi.
