### PR TITLE
Move hint to separate component

### DIFF
--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -24,13 +24,13 @@ import {
     faLongArrowRight,
     faLongArrowLeft,
     faQuestionCircle,
-    faExclamationCircle,
     faUndo,
 } from '@fortawesome/pro-regular-svg-icons';
 import {
     faInfoCircle as fasInfoCircle,
     faVideo,
     faVolumeSlash,
+    faExclamationCircle,
     faVolume,
     faFish,
     faPlayCircle,
@@ -43,6 +43,7 @@ import {
 library.add(
     faInfoCircle,
     fasInfoCircle,
+    faExclamationCircle,
     faVideo,
     faFish,
     faBullseyePointer,

--- a/src/app/src/components/QuizHint.js
+++ b/src/app/src/components/QuizHint.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { string } from 'prop-types';
+import styled from 'styled-components';
+import { Box } from 'rebass';
+import { Text } from './custom-styled-components';
+import { themeGet } from 'styled-system';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const StyledQuizHint = styled(Box)`
+    background: ${themeGet('colors.greens.3')};
+    text-align: center;
+    width: fit-content;
+    margin-left: auto;
+`;
+
+const QuizHint = ({ hint }) => (
+    <StyledQuizHint>
+        <Text variant='small'>
+            <FontAwesomeIcon icon={['fas', 'exclamation-circle']} />
+            &nbsp;
+            {hint}
+        </Text>
+    </StyledQuizHint>
+);
+
+QuizHint.propTypes = {
+    hint: string.isRequired,
+};
+
+export default QuizHint;

--- a/src/app/src/components/QuizQuestion.js
+++ b/src/app/src/components/QuizQuestion.js
@@ -6,6 +6,7 @@ import { themeGet } from 'styled-system';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import QuizOption from './QuizOption';
+import QuizHint from './QuizHint';
 
 import { QuizFish } from '../util/QuizFish';
 import { Fish } from '../util/Fish';
@@ -20,6 +21,12 @@ const Options = styled(Flex)`
     flex-direction: row;
     flex-wrap: wrap;
     text-align: center;
+`;
+
+const GetHintButton = styled(Button)`
+    background: transparent;
+    width: fit-content;
+    margin-left: auto;
 `;
 
 const StyledQuizOption = styled(QuizOption)`
@@ -58,13 +65,22 @@ class QuizQuestion extends React.Component {
         const { guessed, usedHint } = this.state;
 
         const showHint = guessed.length > 0 || usedHint;
+
         // TODO (Issue #96): Remove the default value here when we get hint text
-        let hint = showHint
-            ? answer.hint || `its ${answer.commonName}`
-            : 'Get a hint';
+        let hint = answer.hint || `it's ${answer.commonName}`;
         if (guessed.length > 0) {
             hint = 'Almost! ' + hint;
         }
+
+        const hintTag = showHint ? (
+            <QuizHint hint={hint} />
+        ) : (
+            <GetHintButton onClick={() => this.setState({ usedHint: true })}>
+                <FontAwesomeIcon icon={['fas', 'info-circle']} />
+                &nbsp;Give me a hint
+            </GetHintButton>
+        );
+
         const options = choices.map((fish, idx) => (
             <StyledQuizOption
                 key={idx}
@@ -78,11 +94,7 @@ class QuizQuestion extends React.Component {
         return (
             <StyledQuizQuestion>
                 <Options>{options}</Options>
-                <Button onClick={() => this.setState({ usedHint: true })}>
-                    <FontAwesomeIcon icon={['fas', 'info-circle']} />
-                    &nbsp;
-                    {hint}
-                </Button>
+                {hintTag}
             </StyledQuizQuestion>
         );
     }


### PR DESCRIPTION
## Overview

The quiz hint will animate in. This will be easier if the hint is it's own component. This PR sets up the hint for animation by Design.

Connects #124 

### Demo

![hint](https://user-images.githubusercontent.com/10568752/62154048-eddc6b80-b2d3-11e9-8267-a1c933362eea.gif)

![hint2](https://user-images.githubusercontent.com/10568752/62154049-eddc6b80-b2d3-11e9-929f-142403c51d0e.gif)
^ giphy took a weird screencapture, but the images looked normal i swear.

## Notes
I did not move the hint button to a new component. I don't believe it will get animated/anything special that would benefit from being a separate component.

## Testing Instructions
Netlify is sufficient.
Play the quiz and interact with the hint. Try to get questions wrong and see the hint at work.