### PR TITLE
Apply transition to tab navigation

### DIFF
--- a/src/app/src/components/Fade.js
+++ b/src/app/src/components/Fade.js
@@ -1,0 +1,121 @@
+/*
+    Adapted from the React-Bootstrap built-in Fade transition
+    https://github.com/react-bootstrap/react-bootstrap/blob/v1.0.0-beta.8/src/Fade.js
+*/
+
+import classNames from 'classnames';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Transition, {
+    ENTERED,
+    ENTERING,
+} from 'react-transition-group/Transition';
+import onEnd from 'dom-helpers/transition/end';
+
+const propTypes = {
+    /**
+     * Show the component; triggers the fade in or fade out animation
+     */
+    in: PropTypes.bool,
+
+    /**
+     * Wait until the first "enter" transition to mount the component (add it to the DOM)
+     */
+    mountOnEnter: PropTypes.bool,
+
+    /**
+     * Unmount the component (remove it from the DOM) when it is faded out
+     */
+    unmountOnExit: PropTypes.bool,
+
+    /**
+     * Run the fade in animation when the component mounts, if it is initially
+     * shown
+     */
+    appear: PropTypes.bool,
+
+    /**
+     * Duration of the fade animation in milliseconds, to ensure that finishing
+     * callbacks are fired even if the original browser transition end events are
+     * canceled
+     */
+    timeout: PropTypes.number,
+
+    /**
+     * Callback fired before the component fades in
+     */
+    onEnter: PropTypes.func,
+    /**
+     * Callback fired after the component starts to fade in
+     */
+    onEntering: PropTypes.func,
+    /**
+     * Callback fired after the has component faded in
+     */
+    onEntered: PropTypes.func,
+    /**
+     * Callback fired before the component fades out
+     */
+    onExit: PropTypes.func,
+    /**
+     * Callback fired after the component starts to fade out
+     */
+    onExiting: PropTypes.func,
+    /**
+     * Callback fired after the component has faded out
+     */
+    onExited: PropTypes.func,
+};
+
+const defaultProps = {
+    in: false,
+    timeout: 300,
+    mountOnEnter: false,
+    unmountOnExit: true,
+    appear: true,
+};
+
+const fadeStyles = {
+    [ENTERING]: 'show',
+    [ENTERED]: 'show',
+};
+
+function triggerBrowserReflow(node) {
+    node.offsetHeight; // eslint-disable-line no-unused-expressions
+}
+
+class Fade extends Component {
+    handleEnter = node => {
+        triggerBrowserReflow(node);
+        if (this.props.onEnter) this.props.onEnter(node);
+    };
+
+    render() {
+        const { className, children, ...props } = this.props;
+
+        return (
+            <Transition
+                addEndListener={onEnd}
+                {...props}
+                onEnter={this.handleEnter}
+            >
+                {(status, innerProps) =>
+                    React.cloneElement(children, {
+                        ...innerProps,
+                        className: classNames(
+                            'fade',
+                            className,
+                            children.props.className,
+                            fadeStyles[status]
+                        ),
+                    })
+                }
+            </Transition>
+        );
+    }
+}
+
+Fade.propTypes = propTypes;
+Fade.defaultProps = defaultProps;
+
+export default Fade;

--- a/src/app/src/components/Navbar.js
+++ b/src/app/src/components/Navbar.js
@@ -11,6 +11,7 @@ import About from './About';
 import SeeTheFishway from './SeeTheFishway';
 import MeetTheFish from './MeetTheFish';
 import QuizHome from './QuizHome';
+import Fade from './Fade';
 import { ABOUT, SEE, MEET, TEST, POSITIONS } from '../util/constants';
 
 const StyledTabs = styled(Tabs)`
@@ -126,27 +127,28 @@ const Navbar = ({ dispatch, activeTab, isQuizVisible }) => {
     };
     return (
         <StyledNavbar hide={isQuizVisible ? 'none' : 'visible'}>
-            {/* unmountOnExit is used to ensure that videos restart when
-            switching from About tab to another tab and back again */}
             <StyledTabs
                 activeKey={activeTab}
-                unmountOnExit={true}
+                transition={Fade}
                 onSelect={key => {
                     dispatch(setActiveTab(key));
                     dispatch(setBackgroundPosition(POSITIONS[key]));
                 }}
             >
+                {/* force un/mount tab views so that tab state resets upon revisit
+                this is most critical for the About tab to restart videos upon re/visit
+                React Bootstrap built-in un/mount for tabs breaks transitions */}
                 <Tab eventKey={ABOUT} title={titles[ABOUT]}>
-                    <About />
+                    {activeTab === ABOUT && <About />}
                 </Tab>
                 <Tab eventKey={SEE} title={titles[SEE]}>
-                    <SeeTheFishway />
+                    {activeTab === SEE && <SeeTheFishway />}
                 </Tab>
                 <Tab eventKey={MEET} title={titles[MEET]}>
-                    <MeetTheFish />
+                    {activeTab === MEET && <MeetTheFish />}
                 </Tab>
                 <Tab eventKey={TEST} title={titles[TEST]}>
-                    <QuizHome />
+                    {activeTab === TEST && <QuizHome />}
                 </Tab>
             </StyledTabs>
         </StyledNavbar>

--- a/src/app/src/components/Navbar.js
+++ b/src/app/src/components/Navbar.js
@@ -125,6 +125,16 @@ const Navbar = ({ dispatch, activeTab, isQuizVisible }) => {
             </Heading>
         ),
     };
+
+    /* force un/mount tab views so that tab state resets upon revisit
+    this is most critical for the About tab to restart videos upon re/visit
+    React Bootstrap built-in un/mount for tabs breaks transitions */
+    const tab = (key, component) => (
+        <Tab eventKey={key} title={titles[key]}>
+            {activeTab === key && component}
+        </Tab>
+    );
+
     return (
         <StyledNavbar hide={isQuizVisible ? 'none' : 'visible'}>
             <StyledTabs
@@ -135,21 +145,10 @@ const Navbar = ({ dispatch, activeTab, isQuizVisible }) => {
                     dispatch(setBackgroundPosition(POSITIONS[key]));
                 }}
             >
-                {/* force un/mount tab views so that tab state resets upon revisit
-                this is most critical for the About tab to restart videos upon re/visit
-                React Bootstrap built-in un/mount for tabs breaks transitions */}
-                <Tab eventKey={ABOUT} title={titles[ABOUT]}>
-                    {activeTab === ABOUT && <About />}
-                </Tab>
-                <Tab eventKey={SEE} title={titles[SEE]}>
-                    {activeTab === SEE && <SeeTheFishway />}
-                </Tab>
-                <Tab eventKey={MEET} title={titles[MEET]}>
-                    {activeTab === MEET && <MeetTheFish />}
-                </Tab>
-                <Tab eventKey={TEST} title={titles[TEST]}>
-                    {activeTab === TEST && <QuizHome />}
-                </Tab>
+                {tab(ABOUT, <About />)}
+                {tab(SEE, <SeeTheFishway />)}
+                {tab(MEET, <MeetTheFish />)}
+                {tab(TEST, <QuizHome />)}
             </StyledTabs>
         </StyledNavbar>
     );

--- a/src/app/src/components/Navbar.js
+++ b/src/app/src/components/Navbar.js
@@ -135,11 +135,14 @@ const Navbar = ({ dispatch, activeTab, isQuizVisible }) => {
         </Tab>
     );
 
+    // TODO (#130): replace false with a transition to apply to Meet the Fish
+    const getTransition = key => (key === MEET ? false : Fade);
+
     return (
         <StyledNavbar hide={isQuizVisible ? 'none' : 'visible'}>
             <StyledTabs
                 activeKey={activeTab}
-                transition={Fade}
+                transition={getTransition(activeTab)}
                 onSelect={key => {
                     dispatch(setActiveTab(key));
                     dispatch(setBackgroundPosition(POSITIONS[key]));

--- a/src/app/src/util/globalStyle.js
+++ b/src/app/src/util/globalStyle.js
@@ -97,6 +97,19 @@ const GlobalStyle = createGlobalStyle`
     .popup-content {
         padding: 0 !important;
     }
+
+    /* CSS Transitions for React Tabs */
+    .tab-content {
+        .fade {
+          opacity: 0;
+          transition: opacity 0.3s ease-in;
+
+          &.active.show {
+            opacity: 1;
+            transition: opacity 0.5s ease-in;
+          }
+        }
+    }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
## Overview

See the commit message for detail. To get tabs transitions set up for design, lift the `Fade` transition included in React-Bootstrap.

Connects #123

### Demo

![transition](https://user-images.githubusercontent.com/10568752/62488914-73a85d00-b793-11e9-8af8-7acbfca62e7a.gif)

### Notes

I didn't find any CSS for the `Fade` transition in the library 🤔 I added our own in `globalStyle`, which hooked into the classes applied via the transition.

## Testing Instructions

Ensure the netlify site behaves as before, plus transitions between tabs. 