### PR TITLE
Keep the quiz nav bar up to date and add hint text

### DIFF
--- a/src/app/src/components/Quiz.js
+++ b/src/app/src/components/Quiz.js
@@ -116,14 +116,16 @@ class Quiz extends React.Component {
                     </QuizBody>
                 </QuizContainer>
             );
-
+        const isQuestionActive = currentResult === null;
         return (
             <Box>
                 <QuizNavbar
                     dispatch={this.props.dispatch}
-                    question={question}
+                    // Trick the navbar into showing results during the guess page
+                    // The cheap solution over restructuring quiz state management
+                    question={isQuestionActive ? question : question + 1}
                     results={results}
-                    isQuestionActive={currentResult === null}
+                    isQuestionActive={isQuestionActive}
                 />
                 <QuizBadge
                     dispatch={this.props.dispatch}

--- a/src/app/src/components/QuizGuess.js
+++ b/src/app/src/components/QuizGuess.js
@@ -80,6 +80,15 @@ const CaptionText = styled(Box)`
     transform: scale(1.25);
 `;
 
+const Hint = styled(Text)`
+    position: absolute;
+    bottom: 5%;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: 42rem;
+    text-align: center;
+`;
+
 const QuizGuess = ({ answer, correct }) => {
     const correctText = (
         <CorrectMessage variant='xxlarge'>Correct!</CorrectMessage>
@@ -109,9 +118,9 @@ const QuizGuess = ({ answer, correct }) => {
                     </CaptionText>
                 </FishContainer>
             </Answer>
-            <Text as='h2' variant='xSmall'>
+            <Hint as='h2' variant='base'>
                 {answer.hint}
-            </Text>
+            </Hint>
         </StyledQuizGuess>
     );
 };

--- a/src/app/src/components/QuizHome.js
+++ b/src/app/src/components/QuizHome.js
@@ -58,11 +58,11 @@ class QuizHome extends Component {
 
         let bonusPoints = 0;
         if (secondsToCompleteQuiz < 31) {
-            bonusPoints += 200;
-        } else if (secondsToCompleteQuiz < 61) {
-            bonusPoints += 150;
-        } else if (secondsToCompleteQuiz < 121) {
             bonusPoints += 100;
+        } else if (secondsToCompleteQuiz < 61) {
+            bonusPoints += 50;
+        } else if (secondsToCompleteQuiz < 121) {
+            bonusPoints += 20;
         }
 
         const medallion = (

--- a/src/app/src/components/QuizMedallion.js
+++ b/src/app/src/components/QuizMedallion.js
@@ -152,7 +152,7 @@ const QuizMedallion = ({ value, isFinalScorePage }) => {
 };
 
 QuizMedallion.propTypes = {
-    score: number,
+    value: number.isRequired,
     isFinalScorePage: bool,
 };
 

--- a/src/app/src/components/QuizNavbar.js
+++ b/src/app/src/components/QuizNavbar.js
@@ -126,7 +126,7 @@ const QuizNavbar = props => {
         const incorrect = result && !correct;
         const setIconTheme = () => {
             if (isCurrent) {
-                return currentTheme;
+                return isQuestionActive ? currentTheme : theme;
             } else if (correct) {
                 return correctTheme;
             } else if (incorrect) {

--- a/src/app/src/components/QuizQuestion.js
+++ b/src/app/src/components/QuizQuestion.js
@@ -75,8 +75,7 @@ class QuizQuestion extends React.Component {
 
         const showHint = guessed.length > 0 || usedHint;
 
-        // TODO (Issue #96): Remove the default value here when we get hint text
-        let hint = answer.hint || `it's ${answer.commonName}`;
+        let hint = answer.hint;
         if (guessed.length > 0) {
             hint = 'Almost! ' + hint;
         }

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -83,7 +83,7 @@ import schuylkillVideo from '../media/about/schuylkill.mp4';
 export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
 export const MAX_IDLE_TIME = 180000; //in ms, should be 180000 (3 minutes)
-export const GUESS_MESSAGE_TIME = 2500; //in ms, should be 2500
+export const GUESS_MESSAGE_TIME = 3000; //in ms, should be 3000
 export const FISH_MODAL_OPEN_DELAY = 1000; //in ms, should be 1000
 export const NUM_QUIZ_QUESTIONS = 5;
 
@@ -902,55 +902,63 @@ export const QUIZ_FISH = [
     {
         ...AMERICAN_SHAD,
         videoPath: americanShadClip,
-        hint: '',
+        hint:
+            'Look for a relatively small and triangular dorsal fin (the fin on the back of the fish)!',
         largePicturePath: americanShadLargeIllustration,
     },
     {
         ...BLUEGILL,
         videoPath: bluegillClip,
-        hint: '',
+        hint:
+            'Look for a round body and a dorsal fin that spans a majority of the back of this species!',
         largePicturePath: bluegillLargeIllustration,
     },
     {
         ...CHANNEL_CATFISH,
         videoPath: channelCatfishClip,
-        hint: '',
+        hint:
+            'Look for a long and lean body and what looks like whiskers around the mouth!',
         largePicturePath: channelCatfishLargeIllustration,
     },
     {
         ...COMMON_CARP,
         videoPath: commonCarpClip,
-        hint: '',
+        hint:
+            'Look for the beautiful chess board-like scales and long dorsal fin!',
         largePicturePath: commonCarpLargeIllustration,
     },
     {
         ...QUILLBACK,
         videoPath: quillbackClip,
-        hint: '',
+        hint:
+            'Look for the stunning silver scales and the long pointy quill of a dorsal fin!',
         largePicturePath: quillbackLargeIllustration,
     },
     {
         ...STRIPED_BASS,
         videoPath: stripedBassClip,
-        hint: '',
+        hint:
+            'Look for the two part dorsal fin, silvery to olive green shading, and horizontal stripes!',
         largePicturePath: stripedBassLargeIllustration,
     },
     {
         ...HYBRID_STRIPED_BASS,
         videoPath: stripedBassHybridClip,
-        hint: '',
+        hint: 'Look for the broken horizontal stripe patterns on the body!',
         largePicturePath: stripedBassHybridLargeIllustration,
     },
     {
         ...WHITE_PERCH,
         videoPath: whitePerchClip,
-        hint: '',
+        hint:
+            'Look for a silvery-white body, a concave small mouth and two independent dorsal fins!',
         largePicturePath: whitePerchLargeIllustration,
     },
     {
         ...WHITE_SUCKER,
         videoPath: whiteSuckerClip,
-        hint: '',
+        hint:
+            'Look for a tail fin composed of two equally-sized lobes (looks like the letter V on its side)!',
         largePicturePath: whiteSuckerLargeIllustration,
     },
 ];


### PR DESCRIPTION
## Overview

The navbar updates according to the question number. The question # doesn't update officially until after the in/correct guess page which means that the navbar shows a stale state of information during the guess page. This PR keeps the navbar up to date. See commits for detail.

Also, this PR adds the quiz hint text to the app. Honestly, I had to edit some of the hint text to fit the app. It should all fit nicely.

Also x2 I made the guess page timer a little longer (2.5 --> 3 s) for time to read the hint text.

Connects #96 , #128 

### Demo

<img width="760" alt="Screen Shot 2019-08-15 at 4 06 59 PM" src="https://user-images.githubusercontent.com/10568752/63124793-1625c480-bf7a-11e9-8416-e8a9a6086bbb.png">

after the first q
<img width="789" alt="Screen Shot 2019-08-15 at 4 07 40 PM" src="https://user-images.githubusercontent.com/10568752/63124794-1625c480-bf7a-11e9-8cac-b4936ed3222a.png">

after the 2nd q
<img width="785" alt="Screen Shot 2019-08-15 at 4 07 46 PM" src="https://user-images.githubusercontent.com/10568752/63124795-1625c480-bf7a-11e9-9819-bc3247ebdd59.png">


## Testing Instructions

Play the quiz!
