### PR TITLE
Unify tense of text for former employee

### DIFF
--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -108,7 +108,7 @@ export const ABOUT_PROFILES = [
         job: 'Former Water Resources Engineer, PWD',
         isFormerEmployee: true,
         description:
-            'Prepares computer models of rivers and streams, works on watershed restoration projects, and develops watershed management plans.',
+            'Prepared computer models of rivers and streams, worked on watershed restoration projects, and developed watershed management plans.',
         videoPath: engineerVideo,
     },
     {


### PR DESCRIPTION
## Overview

Chad, one of the featured employees in the videos in the About section, _used_ to work for PWD. Unify his text around the past-tense.

### Demo

Before:

<img width="223" alt="Screen Shot 2019-09-03 at 11 23 47 AM" src="https://user-images.githubusercontent.com/10568752/64186723-5374c800-ce3d-11e9-8726-71013a99a270.png">


After:

<img width="444" alt="Screen Shot 2019-09-03 at 11 24 52 AM" src="https://user-images.githubusercontent.com/10568752/64186819-77d0a480-ce3d-11e9-829b-25338191e58e.png">


