### PR TITLE
Disable user select via CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The website hosted at the FWW Museum will be displayed on an ELO touchscreen of 
   - *Passive Event Listener Override* set to **True**
   - *Document Level Event Listeners Passive Default* set to **Enabled**
   - *Touch adjustment* set to **Enabled**
+  - *Pull to refresh* set to **Disabled**
 
 
 ### Ports

--- a/src/app/src/util/globalStyle.js
+++ b/src/app/src/util/globalStyle.js
@@ -34,6 +34,7 @@ const GlobalStyle = createGlobalStyle`
         border: 0;
         vertical-align: baseline;
         height: 100%;
+        user-select: none;
     }
     ol, ul {
         list-style: none;


### PR DESCRIPTION
## Overview

Disable the copy text prompt appearing on a long press on the touchscreen

Refs #140

### Demo

Test on the touchscreen

### Notes
There's no way to do this on Chrome itself, the solution has to come from the code -- JS or CSS. The preferred solution is CSS. https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting

I also made a Chrome browser usability improvement and snuck it in in the README.

## Testing Instructions

Test that a long tap doesn't produce the copy prompt.
