### PR TITLE
Polish quiz text and timing

### DIFF
--- a/src/app/src/components/QuizHome.js
+++ b/src/app/src/components/QuizHome.js
@@ -80,6 +80,8 @@ class QuizHome extends Component {
                 ? 'You might be ready for a deeper dive! Let us know if you’d like to learn more about becoming a Fairmount Water Works water steward or getting involved with one of our freshwater mussel outreach programs!'
                 : 'Brush up on on your fish knowledge on the Meet the Fish page or try again to improve your score.';
 
+        const callToActionTextWidth = quizScore < 200 ? 640 : 800;
+
         const quizHomeState = quizScore ? (
             <StyledFinalQuizState>
                 <StyledScoreIntro variant='large'>
@@ -92,10 +94,10 @@ class QuizHome extends Component {
                     </StyledScore>
                     <Text variant='xlarge'>/500 points</Text>
                 </StyledScoreContainer>
-                <Text variant='large' width={880}>
+                <Text variant='large' width={callToActionTextWidth}>
                     {callToActionText}
                 </Text>
-                <Flex alignItems='baseline'>
+                <Flex alignItems='baseline' marginTop={'medium'}>
                     <StyledButton
                         mt='normal'
                         variant='secondary'

--- a/src/app/src/components/QuizHome.js
+++ b/src/app/src/components/QuizHome.js
@@ -73,6 +73,13 @@ class QuizHome extends Component {
             <QuizMedallion value={bonusPoints} isFinalScorePage={true} />
         );
 
+        const callToActionText =
+            quizScore >= 300
+                ? 'You are ready for a deeper dive! Let us know if you’d like to learn more about becoming a Fairmount Water Works water steward or getting involved with one of our freshwater mussel outreach programs!'
+                : quizScore >= 200
+                ? 'You might be ready for a deeper dive! Let us know if you’d like to learn more about becoming a Fairmount Water Works water steward or getting involved with one of our freshwater mussel outreach programs!'
+                : 'Brush up on on your fish knowledge on the Meet the Fish page or try again to improve your score.';
+
         const quizHomeState = quizScore ? (
             <StyledFinalQuizState>
                 <StyledScoreIntro variant='large'>
@@ -85,17 +92,8 @@ class QuizHome extends Component {
                     </StyledScore>
                     <Text variant='xlarge'>/500 points</Text>
                 </StyledScoreContainer>
-
                 <Text variant='large' width={880}>
-                    You might be ready for a deeper dive! Let us know if you’d
-                    like to learn more about becoming a water steward or getting
-                    involved with one of our freshwater mussel outreach
-                    programs!
-                </Text>
-
-                <Text variant='base' width={880}>
-                    Brush up on on your fish knowledge on the Meet the Fish page
-                    or try again to improve your score.
+                    {callToActionText}
                 </Text>
                 <Flex alignItems='baseline'>
                     <StyledButton

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -67,7 +67,7 @@ import schuylkillVideo from '../media/about/schuylkill.mp4';
 export const PAUSE = 'PAUSE';
 export const RESET = 'RESET';
 export const MAX_IDLE_TIME = 180000; //in ms, should be 180000 (3 minutes)
-export const GUESS_MESSAGE_TIME = 3000; //in ms, should be 3000
+export const GUESS_MESSAGE_TIME = 7000; //in ms, should be 7000
 export const FISH_MODAL_OPEN_DELAY = 1000; //in ms, should be 1000
 export const NUM_QUIZ_QUESTIONS = 5;
 


### PR DESCRIPTION
## Overview

As per client feedback, the final call to action should vary based on score bracket and the time between questions should leave time to read all the text.

The client requested the text breaks be at 2 and 3 questions correct -- it's a little more complicated than that because we assign different points based on if you use the hint or guess wrong too. But at 40% (F grade lol) and 60% correct (D- grade lol), I'm defaulting for correct on the 1st try.

I made the quiz guess page 7 seconds 😱 That was enough time to read all the text without rushing, and also inspect the drawing. This is slightly more than double. Hopefully it doesn't make users who reallllly wanna speed through the quiz too bothered. Maybe it'd have been cool if there was an exit hatch like a "continue" button or swipe instead of a timer but here we are in the home stretch!

Connects #144

### Demo

<img width="580" alt="Screen Shot 2019-09-06 at 10 04 45 AM" src="https://user-images.githubusercontent.com/10568752/64434501-ad200100-d08e-11e9-9d29-2c7527a36fc6.png">
<img width="620" alt="Screen Shot 2019-09-06 at 10 05 31 AM" src="https://user-images.githubusercontent.com/10568752/64434502-ad200100-d08e-11e9-8a48-cea0afd1314a.png">
<img width="617" alt="Screen Shot 2019-09-06 at 10 06 03 AM" src="https://user-images.githubusercontent.com/10568752/64434504-ad200100-d08e-11e9-8a7a-ba72de6606f2.png">

## Testing Instructions

Play the quiz and try to get scores <200, 200-299 and 300+ to see the call to action texts
Pretend you're a fresh user and actually read the text in between quiz questions ~~ see how 7 seconds feels
