### PR TITLE
App improvements via client feedback

### DIFF
--- a/src/app/src/components/About.js
+++ b/src/app/src/components/About.js
@@ -31,7 +31,7 @@ const StyledAbout = styled(Flex)`
     }
 
     .slider-slide {
-        opacity: 0.25;
+        opacity: 0;
         transition: opacity 0.25s;
     }
 

--- a/src/app/src/components/About.js
+++ b/src/app/src/components/About.js
@@ -93,7 +93,7 @@ class About extends Component {
 
         return (
             <StyledAbout>
-                <Heading as='h1' textAlign='center'>
+                <Heading as='h1' variant='pageTitle' textAlign='center'>
                     About
                 </Heading>
                 <Carousel

--- a/src/app/src/components/AboutSlide.js
+++ b/src/app/src/components/AboutSlide.js
@@ -35,8 +35,9 @@ const PlayButton = styled(Button)`
 
 const MuteButton = styled(Button)`
     position: absolute;
-    bottom: 0.75rem;
-    left: 1rem;
+    bottom: 0;
+    left: 0;
+    padding: 1rem;
 `;
 
 const VideoDescription = styled(Box)`

--- a/src/app/src/components/Heading.js
+++ b/src/app/src/components/Heading.js
@@ -58,6 +58,26 @@ const Heading = styled(BaseHeading)`
             text-transform: uppercase;
             letter-spacing: 1px;
         `};
+    ${props =>
+        props.variant === 'pageTitle' &&
+        css`
+            font-size: ${themeGet('fontSizes.3')};
+            margin-bottom: ${themeGet('space.normal')};
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+
+            &::after {
+                content: '';
+                display: block;
+                margin-top: ${themeGet('space.small')};
+                width: 4rem;
+                height: 2px;
+                background: ${themeGet('colors.lightblues.0')};
+                opacity: 0.4;
+            }
+        `};
 `;
 
 Heading.displayName = 'Heading';

--- a/src/app/src/components/MeetTheFish.js
+++ b/src/app/src/components/MeetTheFish.js
@@ -112,7 +112,9 @@ const MeetTheFish = ({ showSwipePromptMeetTheFishTab, dispatch }) => {
     return (
         <StyledMeetTheFish>
             <Header>
-                <Heading as='h1'>Meet the Fish</Heading>
+                <Heading as='h1' variant='pageTitle'>
+                    Meet the Fish
+                </Heading>
                 <Subtitle as='p' variant='large'>
                     Did you know over 59 species of fish live in the waterways
                     of Philadelphia? Here are 24 of the most common species.

--- a/src/app/src/components/MeetTheFishModal.js
+++ b/src/app/src/components/MeetTheFishModal.js
@@ -117,7 +117,7 @@ const FishShadow = styled.div`
 `;
 
 const FishCircle = styled.div`
-    background: #d9f6f9;
+    background: #ddf4f0;
     border-radius: 50%;
     position: absolute;
     top: 50%;
@@ -327,7 +327,7 @@ export default class MeetTheFishModal extends Component {
                         icon={['far', link.icon]}
                         pull='left'
                         size='lg'
-                        color='#1fb8c5'
+                        color='#2a8171'
                     />
                     <StyledLinkHeading as='span' variant='xSmall'>
                         {link.text}

--- a/src/app/src/components/MeetTheFishModal.js
+++ b/src/app/src/components/MeetTheFishModal.js
@@ -91,11 +91,11 @@ const StyledLinkHeading = styled(Heading)`
 const FishPictureContainer = styled(Box)`
     position: absolute;
     top: 50%;
-    right: -1rem;
+    right: -3rem;
     transform: translateY(-50%);
 
     img {
-        width: 400px;
+        width: 485px;
         height: auto;
         animation: ${fishBounce} 3s infinite;
         position: relative;
@@ -112,11 +112,12 @@ const FishShadow = styled.div`
     bottom: -10%;
     height: 3%;
     filter: blur(5px);
+    mix-blend-mode: difference;
     animation: ${shadowSize} 3s infinite;
 `;
 
 const FishCircle = styled.div`
-    background: #faf8f3;
+    background: #d9f6f9;
     border-radius: 50%;
     position: absolute;
     top: 50%;
@@ -325,8 +326,8 @@ export default class MeetTheFishModal extends Component {
                     <FontAwesomeIcon
                         icon={['far', link.icon]}
                         pull='left'
-                        opacity='0.8'
                         size='lg'
+                        color='#1fb8c5'
                     />
                     <StyledLinkHeading as='span' variant='xSmall'>
                         {link.text}

--- a/src/app/src/components/QuizHome.js
+++ b/src/app/src/components/QuizHome.js
@@ -121,7 +121,7 @@ class QuizHome extends Component {
             <>
                 <StyledFinalQuizState>
                     <Box width={880} mb='4'>
-                        <Heading as='h1' variant='medium'>
+                        <Heading as='h1' variant='pageTitle'>
                             Test your skills
                         </Heading>
                         <Text as='p' variant='large'>

--- a/src/app/src/components/QuizNavbar.js
+++ b/src/app/src/components/QuizNavbar.js
@@ -64,7 +64,7 @@ const correctTheme = {
 const incorrectTheme = {
     sw: '50px',
     s: 'rgba(49, 86, 105, 0.8)',
-    c: 'rgba(255, 255, 255, 0.38)',
+    c: 'rgba(41, 104, 130, 0.5)',
 };
 
 const FishIcon = styled(Box)`
@@ -87,9 +87,11 @@ const CorrectIcon = styled(FishIcon)`
 
 const IncorrectIcon = styled(FishIcon)`
     .icon {
-        color: ${themeGet('colors.white')};
+        color: ${themeGet('colors.teals.0')};
         top: 0;
         left: 54%;
+        opacity: 0.5;
+        mix-blend-mode: screen;
     }
 `;
 

--- a/src/app/src/components/SeeTheFishway.js
+++ b/src/app/src/components/SeeTheFishway.js
@@ -96,7 +96,7 @@ const SeeTheFishway = ({ showConnectionError }) => {
     return (
         <StyledSeeTheFishway>
             <SeeTheFishwayTray>
-                <Box>
+                <Box width={880}>
                     <PageTitle as='h1'>See the Fishway</PageTitle>
                     <Text as='p' variant='large'>
                         During the Spring migration, the river becomes a living

--- a/src/app/src/components/SeeTheFishway.js
+++ b/src/app/src/components/SeeTheFishway.js
@@ -15,14 +15,14 @@ const StyledSeeTheFishway = styled(Flex)`
     height: 100%;
 `;
 
-const PageTitle = styled(Heading)`
-    margin-bottom: ${themeGet('space.small')};
-`;
-
 const SeeTheFishwayTray = styled(Flex)`
     flex-direction: column;
     width: 100%;
     padding: ${themeGet('space.comfortable')};
+`;
+
+const StyledPageTitle = styled(Heading)`
+    align-items: flex-start;
 `;
 
 const Subtitle = styled(Heading)`
@@ -97,7 +97,9 @@ const SeeTheFishway = ({ showConnectionError }) => {
         <StyledSeeTheFishway>
             <SeeTheFishwayTray>
                 <Box width={880}>
-                    <PageTitle as='h1'>See the Fishway</PageTitle>
+                    <StyledPageTitle as='h1' variant='pageTitle'>
+                        See the Fishway
+                    </StyledPageTitle>
                     <Text as='p' variant='large'>
                         During the Spring migration, the river becomes a living
                         highway for fish and other aquatic species. A video

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -254,7 +254,7 @@ export const FISH_HIGHLIGHTS = [
             'A turtle moves downstream through the ladder, carried along by the current.',
     },
     {
-        commonName: 'Snake',
+        commonName: 'River Snake',
         video: snakeVideo,
         photo: snakePhoto,
         timestamp: 1115907780000,

--- a/src/app/src/util/theme.js
+++ b/src/app/src/util/theme.js
@@ -70,7 +70,7 @@ export default {
         large: '8rem',
     },
     maxWidths: {
-        xsmall: '30rem',
+        xsmall: '25rem',
         small: '42.875rem',
         med: '90rem',
         wide: '104.500rem',


### PR DESCRIPTION
## Overview
Design changes per client feedback.

Connects #144 

### Demo
Underline titles & shorten width of See the Fishway text
![Screen Shot 2019-09-09 at 8 55 58 AM](https://user-images.githubusercontent.com/5672295/64532666-f0bd7980-d2df-11e9-934d-b91e7519919c.png)
![Screen Shot 2019-09-09 at 8 56 06 AM](https://user-images.githubusercontent.com/5672295/64532667-f0bd7980-d2df-11e9-8e57-34ccd0fd5617.png)

Add blues to Meet the Fish modal
![Screen Shot 2019-09-09 at 8 59 20 AM](https://user-images.githubusercontent.com/5672295/64532765-27938f80-d2e0-11e9-9162-00f40b819b99.png)

Make Quiz nav incorrect option less prominent than correct option
![Screen Shot 2019-09-09 at 8 27 07 AM](https://user-images.githubusercontent.com/5672295/64532792-367a4200-d2e0-11e9-8ef2-e6a13bb9fe0f.png)

## Testing Instructions
* `git pull`
* Enter app
* **Navigate to About page**
* Note the underlined title, note that only current slide is visible
* Try tapping mute button—this should feel less difficult due to a larger tap zone
* **Navigate to See the Fishway**
* Note the underlined title and that text does not span entire width of available space anymore
* Select the Snake from the highlight reel, it should now be entitled "River Snake"
* **Navigate to Meet the Fish**
* Note the underlined title
* Tap a fish
* Note the color changes for the modal and that the fish are overlapping the modal quite a bit
* **Navigate to Test your Skills**
* Note the underlined title
* Enter quiz
* Get one question right and one question wrong, note that the navbar colors have changed (incorrect questions are in teals)
